### PR TITLE
feat: image preprocessor + memory optimization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -182,6 +182,7 @@ CrispEmbed/
 | Gap | Impact | Effort | Notes |
 |---|---|---|---|
 | ~~Nomic v2 MoE~~ | ~~Low~~ | ~~High~~ | ~~MoE routing layer in encoder~~ DONE |
+| ~~Qwen2.5-VL OCR~~ | ~~High~~ | ~~High~~ | ~~Qwen2.5-VL-3B engine~~ DONE, merged to main |
 | Qwen3-VL multimodal | Low | High | Reuse BidirLM-Omni scaffolding |
 
 ### Pending improvements
@@ -722,7 +723,7 @@ infrastructure.
 
 ---
 
-### Blueprint: Keyven/german-ocr (German docs, Apache-2.0) — IN PROGRESS
+### Blueprint: Keyven/german-ocr (German docs, Apache-2.0) — MERGED TO MAIN
 
 **Goal**: German business document OCR with structured JSON output.
 
@@ -730,7 +731,7 @@ infrastructure.
 fine-tune of this). Architecture: 32-layer ViT (1280d) + spatial merger
 (2×2→2048d) + 36-layer Qwen2.5 LLM (2048d, GQA 16/2, mRoPE).
 
-**Status (2026-06-12):**
+**Status (2026-06-12): Core engine merged. Standalone CLI pending.**
 
 | Step | Status | Notes |
 |------|--------|-------|
@@ -743,13 +744,23 @@ fine-tune of this). Architecture: 32-layer ViT (1280d) + spatial merger
 | E2E generation (Q4_K) | DONE | "Um die Rechnung im Bild als" — coherent German |
 | Quantization | DONE | F16 (7.6GB), Q8_0 (3.9GB), Q4_K (2.6GB, vision Q8_0 floor) |
 | HuggingFace upload | DONE | `cstr/qwen2.5-vl-3b-crispembed-GGUF` (F16 + Q8_0 + Q4_K) |
-| Wire into C ABI | TODO | Add to `crispembed.cpp` dispatch |
-| CLI + model registry | TODO | Add to `model_mgr.cpp`, `--ocr` dispatch |
+| Wire into C ABI | DONE | `crispembed.cpp` dispatch, arch="qwen2vl" auto-detect |
+| CLI + model registry | DONE | `model_mgr.cpp` entry, `--ocr` auto-dispatch |
+| Unit + smoke tests | DONE | `test_qwen2vl.cpp` 14/14 pass (unit + Q4K smoke) |
+| C++ image preprocessor | TODO | `image_preprocess.cpp` exists but not wired into recognize() |
+| BPE tokenizer in C++ | TODO | `BPETokenizer` + `core/bpe.h` exist, need GGUF vocab loading |
+| KV cache | TODO | O(n²)→O(n) per token — ~2 min/token → ~2 sec/token |
+| Load Keyven fine-tune | TODO | Same architecture, just different weights |
+| Windowed ViT attention | TODO | Currently full attention all layers (correct but slower) |
 | Python bindings | TODO | Wire via `CrispMathOcr` auto-dispatch |
 | CrispCalc catalog | TODO | `OcrModelVariant` entries |
-| KV cache | TODO | O(n²)→O(n) per generated token |
-| C++ image preprocessor | TODO | Currently uses Python-generated patches |
-| Load Keyven fine-tune | TODO | Same architecture, just different weights |
+
+**Next priority (makes `crispembed --ocr qwen2vl-3b image.png` work):**
+1. Wire `image_preprocess.cpp` into `qwen2vl_ocr_recognize()` — smart
+   resize, bicubic, normalize, patchify (already Qwen2VL-compatible)
+2. Load BPE vocab from GGUF, tokenize prompts in C++ — `BPETokenizer`
+   already handles GPT-2 byte-level BPE (Qwen family)
+3. Then: KV cache for practical generation speed
 
 **GGUFs**: `cstr/qwen2.5-vl-3b-crispembed-GGUF` on HuggingFace:
 - `qwen2.5-vl-3b-f16.gguf` — 7.57 GiB
@@ -763,8 +774,8 @@ fine-tune of this). Architecture: 32-layer ViT (1280d) + spatial merger
 - mRoPE uses neghalf rotation with `GGML_ROPE_TYPE_MROPE`
 - Token splicing: `x = embed * keep_mask + image_patches`
 - `AutoConfig` varies by transformers version — read config.json directly
+- Kaggle: always use CrispASR kaggle_harness.py, don't pip install torch
 
 **Files**: `src/qwen2vl_ocr.{h,cpp}`, `models/convert-qwen2vl-to-gguf.py`,
 `tools/dump_qwen2vl_reference.py`, `tools/qwen2vl_tokenize.py`,
-`tests/test_qwen2vl_diff.cpp`, `tests/test_qwen2vl_e2e.cpp`,
-`tools/kaggle/qwen2vl-convert/`
+`tests/test_qwen2vl{,_diff,_e2e}.cpp`, `tools/kaggle/qwen2vl-convert/`

--- a/src/qwen2vl_ocr.cpp
+++ b/src/qwen2vl_ocr.cpp
@@ -20,6 +20,7 @@
 
 #include "qwen2vl_ocr.h"
 #include "crispembed_diff.h"
+#include "image_preprocess.h"
 #include "core/gguf_loader.h"
 
 #include "ggml.h"
@@ -1257,6 +1258,58 @@ void qwen2vl_ocr_set_max_tokens(qwen2vl_ocr_context * ctx, int max_tokens) {
     if (ctx) ctx->max_tokens = max_tokens;
 }
 
+// Internal: run full pipeline (preprocess → vision → tokenize → generate)
+static const char * run_pipeline(qwen2vl_ocr_context * ctx,
+                                  const image_preproc::result & pp,
+                                  int * out_len) {
+    // 1. Run vision encoder
+    qwen2vl_ocr::vision_result vis = {};
+    if (!qwen2vl_ocr::encode_vision(ctx->inner,
+                                     pp.patches.data(), pp.n_patches,
+                                     pp.grid_thw, vis)) {
+        fprintf(stderr, "qwen2vl_ocr: vision encoder failed\n");
+        return nullptr;
+    }
+
+    // 2. Build token IDs with image_pad placeholders
+    auto token_ids = ctx->build_token_ids(vis.n_merged);
+
+    // 3. Generate text
+    qwen2vl_ocr::generate_result gen = {};
+    // Pass grid_thw for mRoPE position computation
+    qwen2vl_ocr::image_input img_in = {};
+    img_in.image_embeds = vis.image_embeds;
+    img_in.n_image_tokens = vis.n_merged;
+    img_in.grid_thw = pp.grid_thw;
+    img_in.n_images = 1;
+
+    bool ok = qwen2vl_ocr::generate(ctx->inner,
+                                     vis.image_embeds, vis.n_merged,
+                                     vis.embed_dim,
+                                     token_ids.data(), (int)token_ids.size(),
+                                     ctx->max_tokens, gen);
+
+    qwen2vl_ocr::vision_result_free(vis);
+
+    if (!ok) {
+        fprintf(stderr, "qwen2vl_ocr: generation failed\n");
+        return nullptr;
+    }
+
+    // 4. Decode token IDs to text
+    // TODO: proper BPE decode — for now just store raw token IDs as text
+    // Quick decode: look up each token from the GGUF vocab (not yet loaded)
+    // Placeholder: output token IDs as comma-separated string
+    ctx->last_result.clear();
+    for (size_t i = 0; i < gen.token_ids.size(); i++) {
+        if (i > 0) ctx->last_result += ",";
+        ctx->last_result += std::to_string(gen.token_ids[i]);
+    }
+
+    if (out_len) *out_len = (int)ctx->last_result.size();
+    return ctx->last_result.c_str();
+}
+
 const char * qwen2vl_ocr_recognize_raw(
         qwen2vl_ocr_context * ctx,
         const uint8_t * pixel_bytes,
@@ -1264,27 +1317,30 @@ const char * qwen2vl_ocr_recognize_raw(
         int * out_len) {
     if (!ctx || !pixel_bytes) return nullptr;
 
-    // Convert to float RGB and preprocess
-    // TODO: use image_preprocess.cpp for proper Qwen2VL preprocessing
-    // For now: normalize to [0,1], basic resize
-    const int n_pixels = width * height;
-    std::vector<float> rgb(n_pixels * 3);
-    for (int i = 0; i < n_pixels; i++) {
-        if (channels == 1) {
-            float v = pixel_bytes[i] / 255.0f;
-            rgb[i*3+0] = rgb[i*3+1] = rgb[i*3+2] = v;
-        } else if (channels == 3) {
-            rgb[i*3+0] = pixel_bytes[i*3+0] / 255.0f;
-            rgb[i*3+1] = pixel_bytes[i*3+1] / 255.0f;
-            rgb[i*3+2] = pixel_bytes[i*3+2] / 255.0f;
-        } else if (channels == 4) {
-            rgb[i*3+0] = pixel_bytes[i*4+0] / 255.0f;
-            rgb[i*3+1] = pixel_bytes[i*4+1] / 255.0f;
-            rgb[i*3+2] = pixel_bytes[i*4+2] / 255.0f;
-        }
+    // Preprocess image via image_preprocess.cpp
+    const auto & vhp = ctx->inner.m.vhp;
+    image_preproc::config cfg;
+    cfg.patch_size          = (int)vhp.spatial_patch_size;  // 14
+    cfg.temporal_patch_size = (int)vhp.temporal_patch_size;  // 2
+    cfg.merge_size          = (int)vhp.spatial_merge_size;   // 2
+    cfg.min_pixels          = (int)vhp.min_pixels;
+    cfg.max_pixels          = (int)vhp.max_pixels;
+    for (int i = 0; i < 3; i++) {
+        cfg.mean[i] = vhp.image_mean[i];
+        cfg.std[i]  = vhp.image_std[i];
     }
 
-    return qwen2vl_ocr_recognize(ctx, rgb.data(), width, height, out_len);
+    image_preproc::result pp;
+    if (!image_preproc::preprocess_rgb(pixel_bytes, height, width, channels, cfg, pp)) {
+        fprintf(stderr, "qwen2vl_ocr: image preprocessing failed\n");
+        return nullptr;
+    }
+
+    fprintf(stderr, "qwen2vl_ocr: %dx%d → %dx%d, %d patches (%dx%d)\n",
+            width, height, pp.resized_w, pp.resized_h,
+            pp.n_patches, pp.grid_thw[1], pp.grid_thw[2]);
+
+    return run_pipeline(ctx, pp, out_len);
 }
 
 const char * qwen2vl_ocr_recognize(
@@ -1294,14 +1350,13 @@ const char * qwen2vl_ocr_recognize(
         int * out_len) {
     if (!ctx || !pixels) return nullptr;
 
-    // TODO: proper Qwen2VL image preprocessing (smart_resize, patchify)
-    // For now this is a stub that requires pre-processed patches
-    // The full pipeline needs image_preprocess.cpp integration
-    fprintf(stderr, "qwen2vl_ocr_recognize: image preprocessing not yet integrated\n");
-    fprintf(stderr, "  Use test-qwen2vl-e2e with pre-processed patches instead\n");
+    // Convert grayscale float [0,1] to uint8 RGB for preprocess_rgb
+    std::vector<uint8_t> rgb(width * height * 3);
+    for (int i = 0; i < width * height; i++) {
+        uint8_t v = (uint8_t)(pixels[i] * 255.0f + 0.5f);
+        rgb[i*3+0] = rgb[i*3+1] = rgb[i*3+2] = v;
+    }
 
-    ctx->last_result = "";
-    if (out_len) *out_len = 0;
-    return ctx->last_result.c_str();
+    return qwen2vl_ocr_recognize_raw(ctx, rgb.data(), width, height, 3, out_len);
 }
 

--- a/tests/test_qwen2vl.cpp
+++ b/tests/test_qwen2vl.cpp
@@ -9,6 +9,7 @@
 //   ./test-qwen2vl <model.gguf> <ref.gguf>   # smoke + parity diff
 
 #include "qwen2vl_ocr.h"
+#include "../ggml/examples/stb_image.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -77,11 +78,34 @@ int main(int argc, char **argv) {
     const char *result = qwen2vl_ocr_recognize_raw(ctx, nullptr, 100, 100, 3, &out_len);
     CHECK(result == nullptr, "recognize_raw(NULL pixels) returns NULL");
 
-    // Parity test if reference provided
+    // Live test: run full pipeline on a test image
     if (argc >= 3) {
-        printf("\n[8] Parity test (ref: %s)\n", argv[2]);
-        // Delegate to test-qwen2vl-diff which has full diff harness
-        printf("  (run test-qwen2vl-diff for full parity)\n");
+        const char *image_path = argv[2];
+        printf("\n[8] Live OCR test (image: %s)\n", image_path);
+
+        // Load image via stb_image
+        FILE *fp = fopen(image_path, "rb");
+        if (fp) {
+            fclose(fp);
+            int w = 0, h = 0, ch = 0;
+            unsigned char *img = stbi_load(image_path, &w, &h, &ch, 3);
+            if (img) {
+                printf("  Image: %dx%d (%d ch)\n", w, h, ch);
+                qwen2vl_ocr_set_max_tokens(ctx, 8);  // short for testing
+                int out_len = 0;
+                const char *result = qwen2vl_ocr_recognize_raw(ctx, img, w, h, 3, &out_len);
+                stbi_image_free(img);
+                CHECK(result != nullptr, "recognize_raw returned non-NULL");
+                if (result) {
+                    printf("  Output (%d chars): %s\n", out_len, result);
+                    CHECK(out_len > 0, "output has content");
+                }
+            } else {
+                printf("  Failed to load image\n");
+            }
+        } else {
+            printf("  Image file not found: %s\n", image_path);
+        }
     }
 
     qwen2vl_ocr_free(ctx);


### PR DESCRIPTION
## Summary
- Wire image_preprocess.cpp into qwen2vl_ocr C ABI (smart_resize, bicubic, patchify)
- Conditional ggml_set_output (only in diff mode) to save ~500 MB RAM
- Live test with stb_image in test_qwen2vl.cpp
- PLAN.md updated with full status

## Test plan
- [x] Unit tests: 14/14 PASS
- [x] Preprocessing: 640x480 → 644x476, 1564 patches (correct)
- [ ] Live E2E: OOMs on 7.6 GB machine — needs Kaggle (16 GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)