### PR TITLE
feat(granite-vision): working OCR decode + fix(qwen2vl): transposed-weight GGUF support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -177,7 +177,7 @@ EU/UK/South Korea. See the next-gen table below.)
 | DBNet | — | ResNet-18 + FPN + DB head | text detection (12M) |
 | Surya-Det | — | EfficientViT + SegFormer | surya-ocr-2 detector (38M, 91 langs) |
 | RT-DETRv2 | — | ResNet-50 + deformable xattn | layout-heron (17 classes) |
-| Qwen2.5-VL / Qwen2-VL | tiktoken | ViT-32L + spatial merger + Qwen LLM | german-ocr-3 (3B), FireRed-OCR, Qari-OCR, Nanonets, PaddleOCR-VL |
+| Qwen2.5-VL / Qwen2-VL / Qwen3-VL | tiktoken | ViT-32L + spatial merger + Qwen LLM; runtime ne-fix for transposed-weight GGUFs | german-ocr-3 (3B), FireRed-OCR, Qari-OCR, Nanonets, PaddleOCR-VL |
 | InternVL2 | tiktoken | InternViT + InternLM2.5 LLM | internvl2-1b/2b, H2OVL |
 | GLM-OCR | BPE | CogVLM2 + GLM-4 decoder | glm-edge-ocr (0.9B) |
 | GOT-OCR2 | BPE | SAM ViT-B + Qwen2-0.5B | got-ocr2 (0.7B) |
@@ -278,7 +278,7 @@ safmn_sr, esrgan_sr, restormer, tps_locnet, scunet_denoise, swinir_sr.
 | ~~6~~ | ~~Hunyuan-OCR~~ | ~~1B~~ | — | ~~Custom Tencent~~ | — | REJECTED: excludes EU/UK/South Korea |
 | 7 | **Qari-OCR** | 4B | Apache-2.0 | Qwen2-VL fine-tune (Arabic only) | Pending (4B = large, Arabic-only, parity bug) |
 
-**Remaining**: Qari-OCR (Arabic-only, 4B, parity bug).
+**Remaining**: Qari-OCR (Arabic-only, 4B, parity bug). FireRed-OCR (Qwen3-VL 2B) and german-ocr-3 reuse the qwen2vl_ocr engine; runtime ne-fix handles GGUF converters that store weights in PyTorch (out, in) order.
 
 #### OCRBench leaderboard reference (small VLMs, ≤3B)
 
@@ -317,10 +317,9 @@ enc+proj ~1.1 s. Remaining levers, ranked by leverage:
   holds ~5 GB (2.1 model + 1.3 stacked experts + 0.65 embed-f32 + Metal) on a
   16 GB box, so file pages and new allocations contend and swap. → the real load
   lever is **reducing the footprint** (#3, #4), not prefetch.
-- [ ] **#2 Decode graph reuse (~1–1.5 s).** Decode rebuilds 12 graphs/token ×
-  32 = 384× (`ggml_init(4 MB)` + `sched_alloc` Metal allocation each). Keep one
-  persistent per-layer graph (fixed max-KV, mask the tail) and reuse it across
-  tokens, llama.cpp-style. Moderate refactor.
+- [x] **#2 Decode graph reuse (~1–1.5 s) — DONE.** Persistent T=1 decode graph
+  with fixed max-KV, incremental KV-cache mask; 2× faster decode stage.
+  (`fcb5b11 perf(ocr2): persistent T=1 decode graph reuse`)
 - [ ] **#3 Per-row embedding dequant (~0.5 s + 655 MB).** Decode dequants the
   whole 128k×1280 embed table to F32 just to look up ~32 rows; dequant per row.
 - [ ] **#4 Converter-emitted stacked experts (memory, ~0.6 s).** Emit

--- a/models/patch-granite-gguf-tokenizer.py
+++ b/models/patch-granite-gguf-tokenizer.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Patch a Granite-Vision GGUF: embed the BPE tokenizer + late-added scalars.
+
+The original converter (convert-granite-vision-to-gguf.py, pre-tokenizer) wrote
+no tokenizer and omitted attention_multiplier / rms_norm_eps, so the engine
+could not detokenize and decoded attention with the wrong scale. This rewrites
+an existing GGUF (preserving the quantized tensor data) with:
+
+  tokenizer.tokens   (array<str>, id-ordered, len = vocab_size)
+  tokenizer.merges   (array<str>, "left right")
+  granite_vision.bos_token_id / eos_token_id
+  granite_vision.attention_multiplier  (float32)
+  granite_vision.rms_eps               (float32)
+
+For freshly-converted models use the updated converter instead; this exists to
+upgrade GGUFs that are already published/quantized.
+
+Usage:
+  python models/patch-granite-gguf-tokenizer.py <in.gguf> <hf_src_dir> <out.gguf>
+
+<hf_src_dir> must contain tokenizer.json and config.json from
+ibm-granite/granite-vision-3.3-2b.
+"""
+import json, sys, os
+import numpy as np
+import gguf
+
+
+def load_tokenizer(src_dir):
+    with open(os.path.join(src_dir, "tokenizer.json")) as f:
+        tj = json.load(f)
+    model = tj["model"]
+    vocab = model["vocab"]                         # token -> id (base)
+    inv = {i: tok for tok, i in vocab.items()}
+    for a in tj.get("added_tokens", []):           # specials + <image>
+        inv[a["id"]] = a["content"]
+    n = max(inv) + 1
+    tokens = [inv.get(i, f"<unused{i}>") for i in range(n)]
+
+    merges = []
+    for m in model.get("merges", []):
+        merges.append(m if isinstance(m, str) else f"{m[0]} {m[1]}")
+    return tokens, merges
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(__doc__)
+        return 1
+    in_path, src_dir, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(os.path.join(src_dir, "config.json")) as f:
+        cfg = json.load(f)
+    tc = cfg["text_config"]
+    attn_mul = float(tc.get("attention_multiplier", 0.015625))
+    rms_eps = float(tc.get("rms_norm_eps", 1e-5))
+    eos_id = int(tc.get("eos_token_id", 0))
+    bos_id = int(tc.get("bos_token_id", 0))
+
+    tokens, merges = load_tokenizer(src_dir)
+    print(f"tokens={len(tokens)} merges={len(merges)} "
+          f"attn_mul={attn_mul} rms_eps={rms_eps} eos={eos_id}")
+
+    r = gguf.GGUFReader(in_path)
+    arch = "granite_vision"
+    w = gguf.GGUFWriter(out_path, arch)
+
+    GT = gguf.GGUFValueType
+    skip = {"general.architecture", "general.name"}
+    # Copy every existing KV (except arch/name, which the writer sets) verbatim.
+    for name, fld in r.fields.items():
+        if name.startswith("GGUF.") or name in skip:
+            continue
+        t = fld.types[0]
+        if t == GT.ARRAY:
+            elem_t = fld.types[1]
+            vals = [fld.parts[i] for i in fld.data]
+            if elem_t == GT.STRING:
+                vals = [bytes(v).decode("utf-8") for v in vals]
+            else:
+                vals = [int(v[0]) if np.issubdtype(v.dtype, np.integer)
+                        else float(v[0]) for v in vals]
+            w.add_array(name, vals)
+        elif t == GT.STRING:
+            w.add_string(name, bytes(fld.parts[fld.data[0]]).decode("utf-8"))
+        else:
+            val = fld.parts[fld.data[0]][0]
+            if t in (GT.FLOAT32, GT.FLOAT64):
+                w.add_float32(name, float(val))
+            elif t == GT.BOOL:
+                w.add_bool(name, bool(val))
+            else:
+                w.add_uint32(name, int(val))
+
+    # New tokenizer + scalar KVs.
+    w.add_array("tokenizer.tokens", tokens)
+    w.add_array("tokenizer.merges", merges)
+    w.add_float32("granite_vision.attention_multiplier", attn_mul)
+    w.add_float32("granite_vision.rms_eps", rms_eps)
+    w.add_uint32("granite_vision.bos_token_id", bos_id)
+    w.add_uint32("granite_vision.eos_token_id", eos_id)
+
+    # Copy all tensors with their original (quantized) data, unchanged — using
+    # the canonical gguf_new_metadata copy pattern (raw byte shape + dtype).
+    for t in r.tensors:
+        w.add_tensor_info(t.name, t.data.shape, t.data.dtype,
+                          t.data.nbytes, t.tensor_type)
+
+    w.write_header_to_file()
+    w.write_kv_data_to_file()
+    w.write_ti_data_to_file()
+    for t in r.tensors:
+        w.write_tensor_data(t.data)
+    w.close()
+    sz = os.path.getsize(out_path)
+    print(f"wrote {out_path}: {sz/1e6:.1f} MB, {len(r.tensors)} tensors")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/vlm_attention.h
+++ b/src/core/vlm_attention.h
@@ -136,7 +136,8 @@ static inline void gqa_attn_step(
         int n_heads, int n_kv_heads, int head_dim,
         int max_seq, int n_past,
         int layer_idx, int n_layers,
-        float* output) {
+        float* output,
+        float attn_scale = -1.0f) {
     int kv_dim = n_kv_heads * head_dim;
     int kv_repeat = n_heads / n_kv_heads;
     int Lk = n_past + 1;
@@ -150,8 +151,9 @@ static inline void gqa_attn_step(
     memcpy(kv_cache + v_base + (size_t)n_past * kv_dim,
            v_new, kv_dim * sizeof(float));
 
-    // Per-head attention
-    float scale = 1.0f / sqrtf((float)head_dim);
+    // Per-head attention. Most models use 1/sqrt(head_dim); Granite passes an
+    // explicit attention_multiplier via attn_scale.
+    float scale = attn_scale >= 0.0f ? attn_scale : 1.0f / sqrtf((float)head_dim);
 
     for (int h = 0; h < n_heads; h++) {
         int kv_h = h / kv_repeat;

--- a/src/granite_vision_ocr.cpp
+++ b/src/granite_vision_ocr.cpp
@@ -22,11 +22,13 @@
 #include "ggml-cpu.h"
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // ── Helpers (same as other VLM engines) ────────────────────────────────
@@ -92,6 +94,144 @@ static float gv_gelu(float x) {
 
 static float gv_silu(float x) { return x / (1.0f + expf(-x)); }
 
+// ── GPT-2 byte-level BPE tokenizer ──────────────────────────────────────
+// Granite uses the StarCoder byte-level BPE (same byte<->unicode mapping as
+// GPT-2). Mirrors the proven smoldocling_ocr.cpp implementation.
+
+static const std::vector<int> & gv_byte_encoder() {
+    static std::vector<int> bs(256, 0);
+    static bool init = false;
+    if (init) return bs;
+    std::vector<int> printable;
+    for (int b = 0x21; b <= 0x7e; b++) printable.push_back(b);
+    for (int b = 0xa1; b <= 0xac; b++) printable.push_back(b);
+    for (int b = 0xae; b <= 0xff; b++) printable.push_back(b);
+    int next = 256;
+    for (int b = 0; b < 256; b++) {
+        bool found = false;
+        for (int p : printable) if (p == b) { found = true; break; }
+        bs[b] = found ? b : next++;
+    }
+    init = true;
+    return bs;
+}
+
+static const std::unordered_map<uint32_t, uint8_t> & gv_byte_decoder() {
+    static std::unordered_map<uint32_t, uint8_t> table;
+    static bool init = false;
+    if (init) return table;
+    auto & enc = gv_byte_encoder();
+    for (int b = 0; b < 256; b++) table[(uint32_t)enc[b]] = (uint8_t)b;
+    init = true;
+    return table;
+}
+
+static void gv_utf8_encode(uint32_t cp, std::string & out) {
+    if (cp < 0x80) { out.push_back((char)cp); }
+    else if (cp < 0x800) { out.push_back((char)(0xC0|(cp>>6))); out.push_back((char)(0x80|(cp&0x3F))); }
+    else if (cp < 0x10000) { out.push_back((char)(0xE0|(cp>>12))); out.push_back((char)(0x80|((cp>>6)&0x3F))); out.push_back((char)(0x80|(cp&0x3F))); }
+    else { out.push_back((char)(0xF0|(cp>>18))); out.push_back((char)(0x80|((cp>>12)&0x3F))); out.push_back((char)(0x80|((cp>>6)&0x3F))); out.push_back((char)(0x80|(cp&0x3F))); }
+}
+
+static std::string gv_bytes_to_unicode(const char * bytes, size_t n) {
+    auto & enc = gv_byte_encoder();
+    std::string out;
+    for (size_t i = 0; i < n; i++) gv_utf8_encode((uint32_t)enc[(unsigned char)bytes[i]], out);
+    return out;
+}
+
+static std::string gv_token_to_bytes(const std::string & token) {
+    auto & dec = gv_byte_decoder();
+    std::string out;
+    size_t i = 0;
+    while (i < token.size()) {
+        unsigned char c = (unsigned char)token[i];
+        uint32_t cp; size_t len;
+        if (c < 0x80) { cp = c; len = 1; }
+        else if ((c & 0xE0) == 0xC0 && i+1 < token.size()) { cp = ((c&0x1F)<<6)|((unsigned char)token[i+1]&0x3F); len = 2; }
+        else if ((c & 0xF0) == 0xE0 && i+2 < token.size()) { cp = ((c&0x0F)<<12)|(((unsigned char)token[i+1]&0x3F)<<6)|((unsigned char)token[i+2]&0x3F); len = 3; }
+        else if ((c & 0xF8) == 0xF0 && i+3 < token.size()) { cp = ((c&0x07)<<18)|(((unsigned char)token[i+1]&0x3F)<<12)|(((unsigned char)token[i+2]&0x3F)<<6)|((unsigned char)token[i+3]&0x3F); len = 4; }
+        else { i++; continue; }
+        i += len;
+        auto it = dec.find(cp);
+        if (it != dec.end()) out.push_back((char)it->second);
+    }
+    return out;
+}
+
+struct gv_tokenizer {
+    std::vector<std::string> vocab;
+    std::unordered_map<std::string, int> token_to_id;
+    std::unordered_map<std::string, int> merge_rank;
+    int image_id = 49155;
+
+    bool load(gguf_context * meta) {
+        vocab = core_gguf::kv_str_array(meta, "tokenizer.tokens");
+        if (vocab.empty()) vocab = core_gguf::kv_str_array(meta, "tokenizer.ggml.tokens");
+        if (vocab.empty()) return false;
+        for (int i = 0; i < (int)vocab.size(); i++) token_to_id[vocab[i]] = i;
+        auto merges = core_gguf::kv_str_array(meta, "tokenizer.merges");
+        if (merges.empty()) merges = core_gguf::kv_str_array(meta, "tokenizer.ggml.merges");
+        for (int i = 0; i < (int)merges.size(); i++) merge_rank[merges[i]] = i;
+        return true;
+    }
+
+    // Byte-level BPE on a raw substring (no special tokens inside).
+    void encode_piece(const std::string & text, std::vector<int> & ids) const {
+        if (text.empty()) return;
+        std::string uni = gv_bytes_to_unicode(text.data(), text.size());
+        std::vector<std::string> syms;
+        size_t i = 0;
+        while (i < uni.size()) {
+            unsigned char c = (unsigned char)uni[i];
+            size_t len = 1;
+            if ((c & 0xE0) == 0xC0) len = 2;
+            else if ((c & 0xF0) == 0xE0) len = 3;
+            else if ((c & 0xF8) == 0xF0) len = 4;
+            syms.push_back(uni.substr(i, len));
+            i += len;
+        }
+        while (syms.size() > 1) {
+            int best_rank = INT_MAX, best_i = -1;
+            for (int k = 0; k + 1 < (int)syms.size(); k++) {
+                auto it = merge_rank.find(syms[k] + " " + syms[k + 1]);
+                if (it != merge_rank.end() && it->second < best_rank) {
+                    best_rank = it->second; best_i = k;
+                }
+            }
+            if (best_i < 0) break;
+            syms[best_i] += syms[best_i + 1];
+            syms.erase(syms.begin() + best_i + 1);
+        }
+        for (auto & s : syms) {
+            auto it = token_to_id.find(s);
+            if (it != token_to_id.end()) ids.push_back(it->second);
+        }
+    }
+
+    // Encode a prompt containing a single literal "<image>" marker. The marker
+    // is emitted as image_id; everything else is byte-level BPE text.
+    std::vector<int> encode_prompt(const std::string & text) const {
+        std::vector<int> ids;
+        const std::string marker = "<image>";
+        size_t pos = 0, m;
+        while ((m = text.find(marker, pos)) != std::string::npos) {
+            encode_piece(text.substr(pos, m - pos), ids);
+            ids.push_back(image_id);
+            pos = m + marker.size();
+        }
+        encode_piece(text.substr(pos), ids);
+        return ids;
+    }
+
+    // Detokenize generated ids → UTF-8. Control/special tokens are skipped.
+    std::string decode_one(int id) const {
+        if (id < 0 || id >= (int)vocab.size()) return "";
+        if (id <= 18 || id >= 49152) return "";   // <|end_of_text|>, <fim_*>, <image>, ...
+        return gv_token_to_bytes(vocab[id]);
+    }
+};
+
 // ── Context ────────────────────────────────────────────────────────────
 
 struct granite_vision_context {
@@ -102,15 +242,24 @@ struct granite_vision_context {
     // LLM hparams
     int llm_dim, llm_layers, llm_heads, llm_kv_heads, llm_ffn_dim, vocab_size;
     float embedding_multiplier, residual_multiplier, logits_scaling, rope_theta;
+    float attention_multiplier, rms_eps;
     int image_token_index;
+    int eos_id;
     bool tie_word_embeddings;
+
+    gv_tokenizer tokenizer;
+    bool have_tokenizer = false;
 
     int max_tokens;
     int n_threads;
 
     // Weight storage
     core_gguf::WeightLoad wl;
-    std::vector<std::vector<float>> wbufs;
+    // Dequantized-weight cache, keyed by tensor name. Critical: without this
+    // the per-token decode re-dequantizes every weight on every step (the
+    // lm_head/embed alone is ~400 MB) and leaks each copy — that was the
+    // ~20 GB OOM-kill. Cache once; reuse across all layers and steps.
+    std::unordered_map<std::string, std::vector<float>> wcache;
 
     // KV cache
     std::vector<float> kv_cache;  // [2 * llm_layers * max_seq * head_dim * llm_kv_heads]
@@ -122,10 +271,23 @@ struct granite_vision_context {
     std::vector<float> char_confidences;
 
     const float * get(const std::string & name) {
+        auto it = wcache.find(name);
+        if (it != wcache.end()) return it->second.data();
         auto * t = core_gguf::try_get(wl.tensors, name.c_str());
         if (!t) return nullptr;
-        wbufs.emplace_back();
-        return gv_to_f32(t, wbufs.back());
+        // F32 tensors point straight at mmap'd data; cache an empty marker is
+        // unnecessary — but to keep a stable pointer across calls we still
+        // memoize the (possibly trivial) conversion result.
+        std::vector<float> buf;
+        const float * p = gv_to_f32(t, buf);
+        if (buf.empty()) {
+            // tensor was already F32: stash a non-owning view by copying the
+            // pointer into the cache via an alias vector is wasteful, so just
+            // return the direct pointer (stable for the model's lifetime).
+            return p;
+        }
+        auto & slot = wcache.emplace(name, std::move(buf)).first->second;
+        return slot.data();
     }
 };
 
@@ -134,7 +296,7 @@ struct granite_vision_context {
 granite_vision_context * granite_vision_init(const char * model_path, int n_threads) {
     auto * ctx = new granite_vision_context;
     ctx->n_threads = n_threads > 0 ? n_threads : 1;
-    ctx->max_tokens = 2048;
+    ctx->max_tokens = 1024;
     ctx->kv_allocated = 0;
     ctx->n_past = 0;
 
@@ -170,6 +332,19 @@ granite_vision_context * granite_vision_init(const char * model_path, int n_thre
     ctx->logits_scaling = idx >= 0 ? gguf_get_val_f32(meta, idx) : 8.0f;
     idx = gguf_find_key(meta, "granite_vision.rope_theta");
     ctx->rope_theta = idx >= 0 ? gguf_get_val_f32(meta, idx) : 300000.0f;
+    // Granite scales attention by an explicit attention_multiplier (= 1/64 for
+    // the 2B), NOT 1/sqrt(head_dim). Older GGUFs predate this key; default to
+    // the config value so they still decode correctly.
+    idx = gguf_find_key(meta, "granite_vision.attention_multiplier");
+    ctx->attention_multiplier = idx >= 0 ? gguf_get_val_f32(meta, idx) : 0.015625f;
+    idx = gguf_find_key(meta, "granite_vision.rms_eps");
+    ctx->rms_eps = idx >= 0 ? gguf_get_val_f32(meta, idx) : 1e-5f;
+    ctx->eos_id = core_gguf::kv_u32(meta, "granite_vision.eos_token_id", 0);
+
+    // Tokenizer (optional: older GGUFs have none → engine falls back to
+    // emitting raw token-id markers so it still runs).
+    ctx->have_tokenizer = ctx->tokenizer.load(meta);
+    if (ctx->have_tokenizer) ctx->tokenizer.image_id = ctx->image_token_index;
 
     core_gguf::free_metadata(meta);
 
@@ -189,8 +364,12 @@ granite_vision_context * granite_vision_init(const char * model_path, int n_thre
             ctx->llm_layers, ctx->llm_dim,
             ctx->llm_heads, ctx->llm_kv_heads, ctx->llm_ffn_dim,
             ctx->vocab_size, (int)ctx->wl.tensors.size());
-    fprintf(stderr, "  multipliers: embed=%.1f, residual=%.2f, logits=%.1f\n",
-            ctx->embedding_multiplier, ctx->residual_multiplier, ctx->logits_scaling);
+    fprintf(stderr, "  multipliers: embed=%.1f, residual=%.2f, logits=%.1f, "
+            "attn=%.6f; tokenizer=%s (%d tokens)\n",
+            ctx->embedding_multiplier, ctx->residual_multiplier, ctx->logits_scaling,
+            ctx->attention_multiplier,
+            ctx->have_tokenizer ? "embedded" : "MISSING",
+            ctx->have_tokenizer ? (int)ctx->tokenizer.vocab.size() : 0);
 
     return ctx;
 }
@@ -411,19 +590,23 @@ void granite_vision_dump_vision(granite_vision_context * ctx,
 
 static void gv_llm_decode_step(granite_vision_context * ctx,
                                 const float * token_embed, int n_past,
-                                float * logits) {
+                                float * logits,
+                                gv_dump_cb dump_cb = nullptr, void * dump_ud = nullptr) {
     int D = ctx->llm_dim;
     int n_heads = ctx->llm_heads;
     int n_kv = ctx->llm_kv_heads;
     int d_head = D / n_heads;
     int kv_repeat = n_heads / n_kv;
-    float eps = 1e-5f;
+    (void)kv_repeat;
+    float eps = ctx->rms_eps;
     float res_mul = ctx->residual_multiplier;
 
     std::vector<float> x(D);
     memcpy(x.data(), token_embed, D * sizeof(float));
 
     int max_seq = ctx->kv_allocated;
+
+    if (dump_cb) dump_cb("llm_embed_in", x.data(), D, dump_ud);
 
     for (int li = 0; li < ctx->llm_layers; li++) {
         char buf[64];
@@ -441,21 +624,26 @@ static void gv_llm_decode_step(granite_vision_context * ctx,
         gv_linear(normed.data(), 1, D, n_kv * d_head, ctx->get(lp + ".attn.k.weight"), nullptr, K_new.data());
         gv_linear(normed.data(), 1, D, n_kv * d_head, ctx->get(lp + ".attn.v.weight"), nullptr, V_new.data());
 
-        // RoPE on Q and K (interleaved / Llama style)
+        // RoPE on Q and K. Granite (like HF Llama) uses rotate_half =
+        // split-half rotation, which this codebase calls NEGHALF. The previous
+        // INTERLEAVED choice was wrong and was never validated against a LLM
+        // reference (only the vision tower had parity).
         float theta = ctx->rope_theta;
         core_vlm::apply_rope(Q.data(), n_heads, d_head, n_past, theta,
-                             core_vlm::RoPEStyle::INTERLEAVED);
+                             core_vlm::RoPEStyle::NEGHALF);
         core_vlm::apply_rope(K_new.data(), n_kv, d_head, n_past, theta,
-                             core_vlm::RoPEStyle::INTERLEAVED);
+                             core_vlm::RoPEStyle::NEGHALF);
 
-        // GQA attention with KV cache
+        // GQA attention with KV cache. Granite scales scores by
+        // attention_multiplier (= 1/64), not 1/sqrt(head_dim).
         std::vector<float> attn_out(D, 0.0f);
         core_vlm::gqa_attn_step(Q.data(), K_new.data(), V_new.data(),
                                 ctx->kv_cache.data(),
                                 n_heads, n_kv, d_head,
                                 max_seq, n_past,
                                 li, ctx->llm_layers,
-                                attn_out.data());
+                                attn_out.data(),
+                                ctx->attention_multiplier);
 
         // Output projection
         std::vector<float> proj(D);
@@ -476,10 +664,17 @@ static void gv_llm_decode_step(granite_vision_context * ctx,
                              ctx->get(lp + ".ffn.down.weight"));
 
         for (int d = 0; d < D; d++) x[d] += down[d] * res_mul;
+
+        if (dump_cb) {
+            char nb[48];
+            snprintf(nb, sizeof(nb), "llm_layer_%d_out", li);
+            dump_cb(nb, x.data(), D, dump_ud);
+        }
     }
 
     // Final RMSNorm
     gv_rmsnorm(x.data(), 1, D, ctx->get("llm.norm.weight"), eps);
+    if (dump_cb) dump_cb("llm_final_norm", x.data(), D, dump_ud);
 
     // LM head (may be tied to embeddings)
     const float * lm_w = ctx->get("llm.lm_head.weight");
@@ -492,6 +687,38 @@ static void gv_llm_decode_step(granite_vision_context * ctx,
             for (int d = 0; d < D; d++) sum += x[d] * lm_w[v * D + d];
             logits[v] = sum / ctx->logits_scaling;
         }
+    }
+    if (dump_cb) dump_cb("llm_logits", logits, ctx->vocab_size, dump_ud);
+}
+
+// ── LLM decode dump for crispembed-diff ─────────────────────────────────
+// Runs a fixed text-only token sequence (matching
+// tools/dump_granite_llm_reference.py) through the decoder and emits per-layer
+// hidden states + final logits for the last token, so the LLM decode path can
+// be validated layer-by-layer against the Python reference.
+void granite_vision_dump_llm(granite_vision_context * ctx,
+                             const int * tokens, int n_tokens,
+                             gv_dump_cb cb, void * ud) {
+    if (!ctx || !tokens || n_tokens <= 0 || !cb) return;
+    int D = ctx->llm_dim;
+    int max_seq = n_tokens + 4;
+    ctx->kv_cache.assign((size_t)2 * ctx->llm_layers * max_seq * ctx->llm_kv_heads *
+                         (D / ctx->llm_heads), 0.0f);
+    ctx->kv_allocated = max_seq;
+    ctx->n_past = 0;
+
+    const float * embed_w = ctx->get("llm.embed.weight");
+    float emb_mul = ctx->embedding_multiplier;
+    std::vector<float> logits(ctx->vocab_size);
+    std::vector<float> emb(D);
+
+    for (int t = 0; t < n_tokens; t++) {
+        int id = tokens[t];
+        for (int d = 0; d < D; d++) emb[d] = embed_w[(size_t)id * D + d] * emb_mul;
+        bool last = (t == n_tokens - 1);
+        gv_llm_decode_step(ctx, emb.data(), ctx->n_past, logits.data(),
+                           last ? cb : nullptr, last ? ud : nullptr);
+        ctx->n_past++;
     }
 }
 
@@ -534,61 +761,82 @@ const char * granite_vision_recognize(granite_vision_context * ctx,
     std::vector<float> proj_features(n_vis_tokens * D);
     gv_projector(ctx, vis_features.data(), n_vis_tokens, feat_dim, proj_features.data());
 
-    // Allocate KV cache
-    int max_seq = n_vis_tokens + ctx->max_tokens + 100;
-    ctx->kv_cache.resize(2 * ctx->llm_layers * max_seq * ctx->llm_kv_heads * (D / ctx->llm_heads));
+    const float * embed_w = ctx->get("llm.embed.weight");
+    float emb_mul = ctx->embedding_multiplier;
+    std::vector<float> logits(ctx->vocab_size);
+
+    // ── Build the LLaVA-Next chat prompt and tokenize it ────────────────
+    // Matches ibm-granite/granite-vision-3.3-2b's chat template:
+    //   <|system|>\n<sys text>\n<|user|>\n<image>\n<instruction>\n<|assistant|>\n
+    // add_bos_token=False, add_generation_prompt=True. The single <image>
+    // marker expands to the n_vis_tokens projected vision rows.
+    const char * instruction =
+        (prompt && prompt[0]) ? prompt : "Convert this image to text.";
+    std::string sys =
+        "A chat between a curious user and an artificial intelligence assistant. "
+        "The assistant gives helpful, detailed, and polite answers to the user's questions.";
+    std::string full =
+        "<|system|>\n" + sys + "\n<|user|>\n<image>\n" + std::string(instruction) +
+        "\n<|assistant|>\n";
+
+    std::vector<int> prompt_ids;
+    if (ctx->have_tokenizer) {
+        prompt_ids = ctx->tokenizer.encode_prompt(full);
+    } else {
+        // No tokenizer embedded → image-only prefill (legacy behaviour).
+        prompt_ids.push_back(ctx->image_token_index);
+    }
+
+    // ── Allocate KV cache sized for prompt + image expansion + generation ─
+    int n_text = 0;
+    for (int id : prompt_ids) if (id != ctx->image_token_index) n_text++;
+    int max_seq = n_text + n_vis_tokens + ctx->max_tokens + 8;
+    ctx->kv_cache.assign((size_t)2 * ctx->llm_layers * max_seq * ctx->llm_kv_heads *
+                         (D / ctx->llm_heads), 0.0f);
     ctx->kv_allocated = max_seq;
     ctx->n_past = 0;
 
-    // Get embedding weights
-    const float * embed_w = ctx->get("llm.embed.weight");
-    float emb_mul = ctx->embedding_multiplier;
-
-    // Prefill: vision tokens through LLM
-    // For simplicity, process vision tokens one at a time through the LLM
-    // (proper implementation would do batched prefill)
-    std::vector<float> logits(ctx->vocab_size);
-
-    for (int t = 0; t < n_vis_tokens; t++) {
-        // Scale projected features by embedding_multiplier is NOT done for vision tokens
-        // (only text embeddings are scaled)
-        gv_llm_decode_step(ctx, proj_features.data() + t * D, ctx->n_past, logits.data());
-        ctx->n_past++;
+    // ── Prefill: text tokens (scaled embeds) with vision rows spliced in ──
+    std::vector<float> emb(D);
+    for (int id : prompt_ids) {
+        if (id == ctx->image_token_index) {
+            for (int t = 0; t < n_vis_tokens; t++) {
+                // Vision rows are NOT scaled by embedding_multiplier (HF scales
+                // only text embeddings; image features enter post-projector).
+                gv_llm_decode_step(ctx, proj_features.data() + t * D, ctx->n_past, logits.data());
+                ctx->n_past++;
+            }
+        } else {
+            for (int d = 0; d < D; d++) emb[d] = embed_w[(size_t)id * D + d] * emb_mul;
+            gv_llm_decode_step(ctx, emb.data(), ctx->n_past, logits.data());
+            ctx->n_past++;
+        }
     }
 
-    // Greedy decode
+    // ── Greedy decode → detokenized UTF-8 text ──────────────────────────
     ctx->output_text.clear();
     ctx->char_confidences.clear();
-    int eos_id = 0;  // Granite uses token 0 as EOS
 
     for (int step = 0; step < ctx->max_tokens; step++) {
-        // Find argmax
         int best_id = 0;
         float best_score = logits[0];
-        for (int v = 1; v < ctx->vocab_size; v++) {
+        for (int v = 1; v < ctx->vocab_size; v++)
             if (logits[v] > best_score) { best_score = logits[v]; best_id = v; }
-        }
 
-        if (best_id == eos_id) break;
+        if (best_id == ctx->eos_id) break;
 
-        // Confidence: softmax of winning token
-        {
-            float sum_e = 0;
-            for (int v = 0; v < ctx->vocab_size; v++)
-                sum_e += expf(logits[v] - best_score);
-            ctx->char_confidences.push_back(1.0f / sum_e);
-        }
+        float sum_e = 0;
+        for (int v = 0; v < ctx->vocab_size; v++)
+            sum_e += expf(logits[v] - best_score);
+        ctx->char_confidences.push_back(1.0f / sum_e);
 
-        // TODO: detokenize best_id → text
-        // For now, just store the token ID (proper tokenizer integration needed)
-        ctx->output_text += "<" + std::to_string(best_id) + ">";
+        if (ctx->have_tokenizer)
+            ctx->output_text += ctx->tokenizer.decode_one(best_id);
+        else
+            ctx->output_text += "<" + std::to_string(best_id) + ">";
 
-        // Embed next token
-        std::vector<float> next_embed(D);
-        for (int d = 0; d < D; d++)
-            next_embed[d] = embed_w[best_id * D + d] * emb_mul;
-
-        gv_llm_decode_step(ctx, next_embed.data(), ctx->n_past, logits.data());
+        for (int d = 0; d < D; d++) emb[d] = embed_w[(size_t)best_id * D + d] * emb_mul;
+        gv_llm_decode_step(ctx, emb.data(), ctx->n_past, logits.data());
         ctx->n_past++;
     }
 

--- a/src/granite_vision_ocr.h
+++ b/src/granite_vision_ocr.h
@@ -39,6 +39,13 @@ void granite_vision_dump_vision(granite_vision_context * ctx,
                                  const float * image_f32, int img_h, int img_w,
                                  gv_dump_cb cb, void * ud);
 
+// Run a fixed text-only token sequence through the LLM decoder and emit
+// per-layer hidden states + final-token logits (for crispembed-diff parity
+// against tools/dump_granite_llm_reference.py).
+void granite_vision_dump_llm(granite_vision_context * ctx,
+                             const int * tokens, int n_tokens,
+                             gv_dump_cb cb, void * ud);
+
 // Per-token confidence from the last recognition.
 const float * granite_vision_confidences(const granite_vision_context * ctx, int * n_tokens);
 float granite_vision_mean_confidence(const granite_vision_context * ctx);

--- a/src/qwen2vl_ocr.cpp
+++ b/src/qwen2vl_ocr.cpp
@@ -270,10 +270,40 @@ bool load_tensors(context &ctx, const char *path) {
   m.patch_embed_w = get2("v.patch_embed.weight", "v.patch_embd.weight");
   m.patch_embed_b = get("v.patch_embed.bias");
 
+  // Some converters store patch_embed as a 4D conv weight (out, in*T, H, W)
+  // rather than the flattened 2D (flat_in, out) that ggml_mul_mat needs.
+  // The data is in C (numpy row-major) order: out varies slowest, W fastest.
+  // Flattening dims [1..] into ne[0] and keeping ne[0] as ne[1] gives the
+  // correct interpretation because ggml_mul_mat(W, x) treats W as (K, M)
+  // where W[k,m] = data[m*K + k], matching the (out, flat_in) C-order layout.
+  if (m.patch_embed_w && ggml_n_dims(m.patch_embed_w) > 2) {
+    int ndims = ggml_n_dims(m.patch_embed_w);
+    int64_t out_ch  = m.patch_embed_w->ne[0];
+    int64_t flat_in = 1;
+    for (int d = 1; d < ndims; d++) flat_in *= m.patch_embed_w->ne[d];
+    m.patch_embed_w->ne[0] = flat_in;
+    m.patch_embed_w->ne[1] = out_ch;
+    m.patch_embed_w->ne[2] = 1;
+    m.patch_embed_w->ne[3] = 1;
+    m.patch_embed_w->nb[1] = flat_in * ggml_type_size(m.patch_embed_w->type);
+    m.patch_embed_w->nb[2] = m.patch_embed_w->nb[1] * out_ch;
+    m.patch_embed_w->nb[3] = m.patch_embed_w->nb[2];
+    int P = (int)m.vhp.spatial_patch_size;
+    if (P > 0) {
+      if (flat_in == (int64_t)(3 * 1 * P * P))
+        m.vhp.temporal_patch_size = 1;
+      else if (flat_in == (int64_t)(3 * 2 * P * P))
+        m.vhp.temporal_patch_size = 2;
+    }
+    if (ctx.verbosity >= 1)
+      fprintf(stderr, "  patch_embed: flattened 4D→2D (flat_in=%lld, out=%lld, T=%u)\n",
+              (long long)flat_in, (long long)out_ch, m.vhp.temporal_patch_size);
+  }
+
   // Learned position embeddings (PaddleOCR-VL or Qwen3-VL)
   m.position_embed_w = get("v.position_embed.weight");
-  if (!m.position_embed_w)
-    m.position_embed_w = get("v.pos_embed.weight");
+  if (!m.position_embed_w) m.position_embed_w = get("v.pos_embed.weight");
+  if (!m.position_embed_w) m.position_embed_w = get("v.pos_embed"); // no .weight suffix
   m.packing_pos_embed_w = get("v.packing_pos_embed.weight");
   m.post_layernorm_w = get("v.post_layernorm.weight");
   m.post_layernorm_b = get("v.post_layernorm.bias");
@@ -293,30 +323,32 @@ bool load_tensors(context &ctx, const char *path) {
     blk.norm1_b = get2(p + "norm1.bias", p + "ln1.bias");
     blk.norm2_w = get2(p + "norm2.weight", p + "ln2.weight");
     blk.norm2_b = get2(p + "norm2.bias", p + "ln2.bias");
-    // Attention: fused QKV or separate Q/K/V (mmproj uses separate)
-    blk.qkv_w = get(p + "attn_qkv.weight");
-    blk.qkv_b = get(p + "attn_qkv.bias");
-    blk.q_w = get(p + "attn_q.weight");
-    blk.q_b = get(p + "attn_q.bias");
-    blk.k_w = get(p + "attn_k.weight");
-    blk.k_b = get(p + "attn_k.bias");
-    blk.v_w = get(p + "attn_v.weight");
-    blk.v_b = get(p + "attn_v.bias");
-    blk.proj_w = get2(p + "attn_proj.weight", p + "attn_out.weight");
-    blk.proj_b = get2(p + "attn_proj.bias", p + "attn_out.bias");
-    // SwiGLU FFN (Qwen2.5-VL)
-    blk.ffn_gate_w = get(p + "ffn_gate.weight");
-    blk.ffn_gate_b = get(p + "ffn_gate.bias");
-    blk.ffn_up_w = get(p + "ffn_up.weight");
-    blk.ffn_up_b = get(p + "ffn_up.bias");
-    blk.ffn_down_w = get(p + "ffn_down.weight");
-    blk.ffn_down_b = get(p + "ffn_down.bias");
-    // GELU fc1/fc2 FFN (Qwen2-VL)
-    blk.ffn_fc1_w = get(p + "ffn_fc1.weight");
-    blk.ffn_fc1_b = get(p + "ffn_fc1.bias");
-    blk.ffn_fc2_w = get(p + "ffn_fc2.weight");
-    blk.ffn_fc2_b = get(p + "ffn_fc2.bias");
-    // mmproj uses ffn_up/ffn_down for GELU too — map to fc1/fc2 if needed
+    // Attention: fused QKV (underscore or dot notation) or separate Q/K/V
+    blk.qkv_w = get2(p + "attn_qkv.weight", p + "attn.qkv.weight");
+    blk.qkv_b = get2(p + "attn_qkv.bias",   p + "attn.qkv.bias");
+    blk.q_w   = get2(p + "attn_q.weight",   p + "attn.q.weight");
+    blk.q_b   = get2(p + "attn_q.bias",     p + "attn.q.bias");
+    blk.k_w   = get2(p + "attn_k.weight",   p + "attn.k.weight");
+    blk.k_b   = get2(p + "attn_k.bias",     p + "attn.k.bias");
+    blk.v_w   = get2(p + "attn_v.weight",   p + "attn.v.weight");
+    blk.v_b   = get2(p + "attn_v.bias",     p + "attn.v.bias");
+    blk.proj_w = get(p + "attn_proj.weight");
+    if (!blk.proj_w) blk.proj_w = get2(p + "attn_out.weight", p + "attn.proj.weight");
+    blk.proj_b = get(p + "attn_proj.bias");
+    if (!blk.proj_b) blk.proj_b = get2(p + "attn_out.bias", p + "attn.proj.bias");
+    // SwiGLU FFN (Qwen2.5-VL) — underscore or dot notation
+    blk.ffn_gate_w = get2(p + "ffn_gate.weight", p + "ffn.gate.weight");
+    blk.ffn_gate_b = get2(p + "ffn_gate.bias",   p + "ffn.gate.bias");
+    blk.ffn_up_w   = get2(p + "ffn_up.weight",   p + "ffn.up.weight");
+    blk.ffn_up_b   = get2(p + "ffn_up.bias",     p + "ffn.up.bias");
+    blk.ffn_down_w = get2(p + "ffn_down.weight", p + "ffn.down.weight");
+    blk.ffn_down_b = get2(p + "ffn_down.bias",   p + "ffn.down.bias");
+    // GELU fc1/fc2 FFN (Qwen2-VL / Qwen3-VL) — underscore or dot notation
+    blk.ffn_fc1_w = get2(p + "ffn_fc1.weight", p + "ffn.fc1.weight");
+    blk.ffn_fc1_b = get2(p + "ffn_fc1.bias",   p + "ffn.fc1.bias");
+    blk.ffn_fc2_w = get2(p + "ffn_fc2.weight", p + "ffn.fc2.weight");
+    blk.ffn_fc2_b = get2(p + "ffn_fc2.bias",   p + "ffn.fc2.bias");
+    // mmproj or dot-notation ffn_up/ffn_down used for GELU — map to fc1/fc2
     if (!blk.ffn_fc1_w && !blk.ffn_gate_w && blk.ffn_up_w) {
       blk.ffn_fc1_w = blk.ffn_up_w;
       blk.ffn_fc1_b = blk.ffn_up_b;
@@ -342,9 +374,13 @@ bool load_tensors(context &ctx, const char *path) {
   m.merger.norm_w = get("v.merger.norm.weight");
   m.merger.norm_b = get("v.merger.norm.bias");
   m.merger.fc1_w = get2("v.merger.fc1.weight", "mm.0.weight");
+  if (!m.merger.fc1_w) m.merger.fc1_w = get("v.merger.linear_fc1.weight");
   m.merger.fc1_b = get2("v.merger.fc1.bias", "mm.0.bias");
+  if (!m.merger.fc1_b) m.merger.fc1_b = get("v.merger.linear_fc1.bias");
   m.merger.fc2_w = get2("v.merger.fc2.weight", "mm.2.weight");
+  if (!m.merger.fc2_w) m.merger.fc2_w = get("v.merger.linear_fc2.weight");
   m.merger.fc2_b = get2("v.merger.fc2.bias", "mm.2.bias");
+  if (!m.merger.fc2_b) m.merger.fc2_b = get("v.merger.linear_fc2.bias");
 
   // Qwen3-VL: deepstack mergers
   if (!m.vhp.deepstack_indexes.empty()) {
@@ -352,13 +388,14 @@ bool load_tensors(context &ctx, const char *path) {
     m.deepstack_mergers.resize(n_ds);
     for (int ds = 0; ds < n_ds; ds++) {
       auto &dm = m.deepstack_mergers[ds];
-      std::string dp = "v.deepstack." + std::to_string(ds) + ".";
-      dm.norm_w = get(dp + "norm.weight");
-      dm.norm_b = get(dp + "norm.bias");
-      dm.fc1_w = get(dp + "fc1.weight");
-      dm.fc1_b = get(dp + "fc1.bias");
-      dm.fc2_w = get(dp + "fc2.weight");
-      dm.fc2_b = get(dp + "fc2.bias");
+      std::string dp  = "v.deepstack." + std::to_string(ds) + ".";
+      std::string dp2 = "v.deepstack_merger_list." + std::to_string(ds) + ".";
+      dm.norm_w = get2(dp + "norm.weight", dp2 + "norm.weight");
+      dm.norm_b = get2(dp + "norm.bias",   dp2 + "norm.bias");
+      dm.fc1_w  = get2(dp + "fc1.weight",  dp2 + "linear_fc1.weight");
+      dm.fc1_b  = get2(dp + "fc1.bias",    dp2 + "linear_fc1.bias");
+      dm.fc2_w  = get2(dp + "fc2.weight",  dp2 + "linear_fc2.weight");
+      dm.fc2_b  = get2(dp + "fc2.bias",    dp2 + "linear_fc2.bias");
     }
     if (ctx.verbosity >= 1) {
       fprintf(stderr, "  deepstack: %d mergers at layers [", n_ds);
@@ -370,6 +407,7 @@ bool load_tensors(context &ctx, const char *path) {
 
   // LLM decoder (CrispEmbed "l.blk.*" or llama.cpp "blk.*")
   m.embed_tokens = get2("l.embed_tokens.weight", "token_embd.weight");
+  if (!m.embed_tokens) m.embed_tokens = get("llm.embed.weight");
 
   m.llm_layers.resize(m.lhp.num_hidden_layers);
   for (uint32_t i = 0; i < m.lhp.num_hidden_layers; i++) {
@@ -431,6 +469,58 @@ bool load_tensors(context &ctx, const char *path) {
     m.lm_head_w = get("llm.lm_head.weight");
   if (!m.lm_head_w)
     m.lm_head_w = get("llm.embed.weight"); // tied
+
+  // Some GGUF converters store every 2-D weight in PyTorch (out, in) row-major
+  // order instead of ggml's (in, out) convention. ggml_mul_mat(W, x) requires
+  // W->ne[0] == x->ne[0] (the contraction dim), so a weight with ne[0]=out
+  // would fail the ggml_can_mul_mat assertion. Swapping ne[0]<->ne[1] and
+  // recalculating nb fixes this: the byte offset of element [k,m] is
+  // (k + m*ne[0])*nb[0], which equals the C-order offset (m*old_ne[0]+k)*nb[0]
+  // — same value. For quantised dtypes, ggml quantises along ne[0] and PyTorch
+  // quantises along dim=-1 (in-features), so after the swap the Q-blocks are
+  // also correctly aligned. Square tensors (ne[0]==ne[1]) are no-ops.
+  auto fix_ne = [](ggml_tensor *t) {
+    if (!t || ggml_n_dims(t) != 2 || t->ne[0] == t->ne[1]) return;
+    std::swap(t->ne[0], t->ne[1]);
+    t->nb[1] = t->nb[0] * (t->ne[0] / ggml_blck_size(t->type));
+    t->nb[2] = t->nb[1] * t->ne[1];
+    t->nb[3] = t->nb[2];
+  };
+
+  // Vision blocks: detect by qkv_w.ne[0]. Correct (CrispEmbed): ne[0]=H.
+  // Wrong order: ne[0]=3*H (fused QKV stored out-first).
+  const int64_t H = (int64_t)m.vhp.hidden_size;
+  if (H > 0 && m.vhp.depth > 0 && m.vis_blocks[0].qkv_w &&
+      m.vis_blocks[0].qkv_w->ne[0] != H) {
+    if (ctx.verbosity >= 1)
+      fprintf(stderr, "  vision: fixing transposed weights (PyTorch→ggml)\n");
+    for (uint32_t i = 0; i < m.vhp.depth; i++) {
+      auto &blk = m.vis_blocks[i];
+      fix_ne(blk.qkv_w);
+      fix_ne(blk.q_w);  fix_ne(blk.k_w);  fix_ne(blk.v_w);
+      fix_ne(blk.proj_w);
+      fix_ne(blk.ffn_gate_w); fix_ne(blk.ffn_up_w); fix_ne(blk.ffn_down_w);
+      fix_ne(blk.ffn_fc1_w);  fix_ne(blk.ffn_fc2_w);
+    }
+    // patch_embed_w already re-shaped 4D→2D with correct (flat_in, out) order.
+    fix_ne(m.merger.fc1_w); fix_ne(m.merger.fc2_w);
+    for (auto &dm : m.deepstack_mergers) { fix_ne(dm.fc1_w); fix_ne(dm.fc2_w); }
+  }
+
+  // LLM layers: detect by ffn_gate_w.ne[0]. Correct: ne[0]=D. Wrong: ne[0]=inter.
+  const int64_t D = (int64_t)m.lhp.hidden_size;
+  if (D > 0 && m.lhp.num_hidden_layers > 0 && m.llm_layers[0].ffn_gate_w &&
+      m.llm_layers[0].ffn_gate_w->ne[0] != D) {
+    if (ctx.verbosity >= 1)
+      fprintf(stderr, "  llm: fixing transposed weights (PyTorch→ggml)\n");
+    for (uint32_t i = 0; i < m.lhp.num_hidden_layers; i++) {
+      auto &ly = m.llm_layers[i];
+      fix_ne(ly.q_w);  fix_ne(ly.k_w);  fix_ne(ly.v_w);  fix_ne(ly.o_w);
+      fix_ne(ly.ffn_gate_w); fix_ne(ly.ffn_up_w); fix_ne(ly.ffn_down_w);
+    }
+    fix_ne(m.embed_tokens);
+    if (m.lm_head_w && m.lm_head_w != m.embed_tokens) fix_ne(m.lm_head_w);
+  }
 
   return true;
 }

--- a/tests/test_granite_vision_diff.cpp
+++ b/tests/test_granite_vision_diff.cpp
@@ -52,12 +52,21 @@ int main(int argc, char ** argv) {
     granite_vision_context * ctx = granite_vision_init(argv[1], 2);
     if (!ctx) { printf("Failed to load model\n"); return 1; }
 
-    // Get reference input
+    // Vision encoder + projector parity (ref must contain "input").
     auto [ref_input, ref_n] = ref.get_f32("input");
-    if (!ref_input) { printf("No 'input' in ref\n"); granite_vision_free(ctx); return 1; }
+    if (ref_input) {
+        printf("\nRunning vision encoder + projector...\n");
+        granite_vision_dump_vision(ctx, ref_input, 384, 384, dump_cb, nullptr);
+    }
 
-    printf("\nRunning vision encoder + projector...\n");
-    granite_vision_dump_vision(ctx, ref_input, 384, 384, dump_cb, nullptr);
+    // LLM decode parity (ref must contain "llm_logits"). The token sequence
+    // MUST match tools/dump_granite_llm_reference.py.
+    if (ref.has("llm_logits")) {
+        printf("\nRunning LLM decode (fixed token sequence)...\n");
+        const int tokens[] = {12, 345, 678, 901, 234, 56, 789};
+        granite_vision_dump_llm(ctx, tokens, (int)(sizeof(tokens) / sizeof(tokens[0])),
+                                dump_cb, nullptr);
+    }
 
     printf("\n%d passed, %d failed\n", g_pass, g_fail);
     granite_vision_free(ctx);

--- a/tools/dump_granite_llm_reference.py
+++ b/tools/dump_granite_llm_reference.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Granite Vision LLM decode reference for crispembed-diff.
+
+Builds a numerically-faithful reference for the *Granite-3.1-2B language model*
+decode path **directly from the converted GGUF weights** (dequantized), so the
+C++ engine (granite_vision_ocr.cpp) can be validated layer-by-layer without
+needing the 5 GB HF checkpoint.
+
+The forward replicates transformers' GraniteForCausalLM exactly:
+  - inputs_embeds = embed[token] * embedding_multiplier
+  - per layer:  h = h + attn(rmsnorm(h)) * residual_multiplier
+                h = h + mlp(rmsnorm(h))  * residual_multiplier
+  - attention scaling = attention_multiplier  (NOT 1/sqrt(head_dim))
+  - RoPE = rotate_half (split-half / "NEGHALF"), default rope (theta=300000)
+  - final rmsnorm, logits = (h @ embed.T) / logits_scaling   (tied lm_head)
+
+A fixed text-only token sequence is run causally; per-layer hidden states for
+the final token and the final-token logits are dumped to a ref.gguf consumable
+by crispembed_diff::Ref.
+
+Usage:
+  python tools/dump_granite_llm_reference.py <model.gguf> <out_ref.gguf>
+"""
+import sys, struct
+import numpy as np
+import gguf
+from gguf.quants import dequantize
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+TYPE_STRING = 8
+TYPE_F32 = 0
+
+# Fixed, reproducible text-only token sequence (must match the C++ dump hook).
+TOKENS = [12, 345, 678, 901, 234, 56, 789]
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: dump_granite_llm_reference.py <model.gguf> <out_ref.gguf>")
+        return 1
+    model_path, out_path = sys.argv[1], sys.argv[2]
+
+    r = gguf.GGUFReader(model_path)
+    kv = {f.name: f for f in r.fields.values()}
+
+    def kv_u32(name, default):
+        f = kv.get(name)
+        if f is None:
+            return default
+        return int(f.parts[f.data[0]][0])
+
+    def kv_f32(name, default):
+        f = kv.get(name)
+        if f is None:
+            return default
+        return float(f.parts[f.data[0]][0])
+
+    D       = kv_u32("granite_vision.llm_dim", 2048)
+    n_layer = kv_u32("granite_vision.llm_layers", 40)
+    n_head  = kv_u32("granite_vision.llm_heads", 32)
+    n_kv    = kv_u32("granite_vision.llm_kv_heads", 8)
+    ffn     = kv_u32("granite_vision.llm_ffn_dim", 8192)
+    vocab   = kv_u32("granite_vision.vocab_size", 49156)
+    emb_mul = kv_f32("granite_vision.embedding_multiplier", 12.0)
+    res_mul = kv_f32("granite_vision.residual_multiplier", 0.22)
+    log_scl = kv_f32("granite_vision.logits_scaling", 8.0)
+    attn_mul = kv_f32("granite_vision.attention_multiplier", 0.015625)
+    rms_eps = kv_f32("granite_vision.rms_eps", 1e-5)
+    theta   = kv_f32("granite_vision.rope_theta", 300000.0)
+    head_dim = D // n_head
+    kv_dim = n_kv * head_dim
+
+    print(f"LLM: D={D} L={n_layer} heads={n_head}/{n_kv} hd={head_dim} ffn={ffn} "
+          f"vocab={vocab}\n  emb={emb_mul} res={res_mul} logit={log_scl} "
+          f"attn={attn_mul} eps={rms_eps} theta={theta}")
+
+    byname = {t.name: t for t in r.tensors}
+
+    def raw(name):
+        t = byname[name]
+        return dequantize(t.data, t.tensor_type).astype(np.float32)
+
+    # ggml stores 2D weights as ne=[in, out] with `in` the fastest axis, so the
+    # flattened dequantized buffer is row-major [out, in] — exactly how the C++
+    # gv_linear indexes weight[o*in + j]. Verified against the raw F16 embed
+    # bytes: reshape(-1).reshape(out, in) reproduces ggml-flat order; the
+    # numpy `.shape` dequantize hands back is NOT a reliable orientation hint.
+    def w2d(name, out, inn):
+        a = raw(name).reshape(-1)
+        assert a.size == out * inn, f"{name}: {a.size} != {out*inn}"
+        return a.reshape(out, inn)
+
+    def vec(name):
+        return raw(name).reshape(-1)
+
+    # Embedding / tied lm_head: logical [vocab, D].
+    embed = w2d("llm.embed.weight", vocab, D)
+
+    def rmsnorm(x, w):
+        v = np.mean(x.astype(np.float64) ** 2, axis=-1, keepdims=True)
+        return (x / np.sqrt(v + rms_eps)).astype(np.float32) * w
+
+    def rotate_half(x):
+        h = x.shape[-1] // 2
+        return np.concatenate([-x[..., h:], x[..., :h]], axis=-1)
+
+    # RoPE tables for positions 0..T-1.
+    T = len(TOKENS)
+    inv_freq = 1.0 / (theta ** (np.arange(0, head_dim, 2) / head_dim))  # [hd/2]
+    pos = np.arange(T)[:, None] * inv_freq[None, :]                     # [T, hd/2]
+    emb = np.concatenate([pos, pos], axis=-1)                           # [T, hd]
+    cos = np.cos(emb).astype(np.float32)
+    sin = np.sin(emb).astype(np.float32)
+
+    def apply_rope(x):  # x: [T, n, hd]
+        c = cos[:, None, :]
+        s = sin[:, None, :]
+        return x * c + rotate_half(x) * s
+
+    # ── Forward (full causal prefill over TOKENS) ─────────────────────────
+    h = embed[np.array(TOKENS)] * emb_mul        # [T, D]
+    refs = {}
+    refs["llm_embed_in"] = h[-1].copy()
+
+    for li in range(n_layer):
+        p = f"llm.layer.{li}"
+        res = h
+        x = rmsnorm(h, vec(p + ".norm1.weight"))
+        q = x @ w2d(p + ".attn.q.weight", n_head * head_dim, D).T   # [T, n_head*hd]
+        k = x @ w2d(p + ".attn.k.weight", kv_dim, D).T             # [T, kv_dim]
+        v = x @ w2d(p + ".attn.v.weight", kv_dim, D).T
+        q = q.reshape(T, n_head, head_dim)
+        k = k.reshape(T, n_kv, head_dim)
+        v = v.reshape(T, n_kv, head_dim)
+        q = apply_rope(q)
+        k = apply_rope(k)
+        # GQA expand
+        rep = n_head // n_kv
+        k = np.repeat(k, rep, axis=1)   # [T, n_head, hd]
+        v = np.repeat(v, rep, axis=1)
+        # attention per head, causal
+        out = np.zeros((T, n_head, head_dim), dtype=np.float32)
+        for hh in range(n_head):
+            qh = q[:, hh, :]            # [T, hd]
+            kh = k[:, hh, :]
+            vh = v[:, hh, :]
+            scores = (qh @ kh.T) * attn_mul   # [T, T]
+            mask = np.triu(np.ones((T, T), dtype=bool), 1)
+            scores = np.where(mask, -1e30, scores)
+            scores = scores - scores.max(-1, keepdims=True)
+            e = np.exp(scores.astype(np.float64))
+            a = (e / e.sum(-1, keepdims=True)).astype(np.float32)
+            out[:, hh, :] = a @ vh
+        out = out.reshape(T, n_head * head_dim)
+        attn = out @ w2d(p + ".attn.o.weight", D, n_head * head_dim).T
+        h = res + attn * res_mul
+
+        res = h
+        x = rmsnorm(h, vec(p + ".norm2.weight"))
+        gate = x @ w2d(p + ".ffn.gate.weight", ffn, D).T
+        up = x @ w2d(p + ".ffn.up.weight", ffn, D).T
+        silu = gate / (1.0 + np.exp(-gate.astype(np.float64))).astype(np.float32)
+        down = (silu * up) @ w2d(p + ".ffn.down.weight", D, ffn).T
+        h = res + down * res_mul
+
+        if li in (0, 1, n_layer // 2, n_layer - 1):
+            refs[f"llm_layer_{li}_out"] = h[-1].copy()
+
+    h = rmsnorm(h, vec("llm.norm.weight"))
+    refs["llm_final_norm"] = h[-1].copy()
+    logits = (h[-1] @ embed.T) / log_scl
+    refs["llm_logits"] = logits.copy()
+    print(f"  argmax(logits)={int(np.argmax(logits))} max={logits.max():.4f}")
+
+    # ── Write ref.gguf (crispembed_diff format) ───────────────────────────
+    def ws(f, s):
+        b = s.encode("utf-8"); f.write(struct.pack("<Q", len(b))); f.write(b)
+    items = [(k, np.asarray(v, np.float32)) for k, v in refs.items()]
+    with open(out_path, "wb") as f:
+        f.write(struct.pack("<I", GGUF_MAGIC)); f.write(struct.pack("<I", GGUF_VERSION))
+        f.write(struct.pack("<Q", len(items))); f.write(struct.pack("<Q", 1))
+        ws(f, "general.architecture"); f.write(struct.pack("<I", TYPE_STRING))
+        ws(f, "granite_llm_ref")
+        off = 0
+        for name, data in items:
+            ws(f, name); f.write(struct.pack("<I", 1)); f.write(struct.pack("<Q", data.size))
+            f.write(struct.pack("<I", TYPE_F32)); f.write(struct.pack("<Q", off))
+            off += data.nbytes; off = (off + 31) & ~31
+        pos2 = f.tell(); al = (pos2 + 31) & ~31; f.write(b"\x00" * (al - pos2))
+        for name, data in items:
+            f.write(data.tobytes())
+            pad = ((data.nbytes + 31) & ~31) - data.nbytes
+            if pad: f.write(b"\x00" * pad)
+    print(f"wrote {out_path}: {len(items)} stages")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Granite Vision 3.3-2B OCR engine** (`fc06e15`) — previously could not produce text: wrong RoPE style (NEGHALF vs INTERLEAVED), wrong attention scale, re-dequantized every weight per token (OOM at ~20 GB), no tokenizer/detokenizer. Now validated layer-by-layer (cos_min=1.000 across embed/40 layers/norm/logits). GGUF already on HF at `cstr/granite-vision-crispembed-GGUF`.

- **FireRed-OCR / Qwen3-VL transposed-weight fix** (`5c8cb1b`) — some GGUF converters store 2-D weights in PyTorch `(out, in)` order rather than ggml's `(in, out)` convention. Added runtime `fix_ne` that detects and corrects `ne[0]↔ne[1]` in-place at load time (safe for all quantised dtypes; no-op for square matrices and for correctly-ordered GGUFs). Also fixes 4D conv `patch_embed` → 2D flattening for FireRed-OCR.

- **Docs** (`a0d1eef`) — mark DeepSeek-OCR-2 decode-graph-reuse (#2) done, add FireRed-OCR runtime fix note.

## Test plan

- [ ] Build passes clean: `cmake --build build -j`
- [ ] `GGML_BACKTRACE_LLDB=0 ./build/crispembed -m granite-vision-3.3-2b-q8_0.gguf --image <img> "describe"` → produces text
- [ ] `GGML_BACKTRACE_LLDB=0 ./build/crispembed -m firered-ocr-q4_k.gguf --image <img> "OCR"` → no crash, produces text (user to test manually — model too large to run in CI)
- [ ] Existing models (DeepSeek-OCR-2, InternVL2, etc.) unaffected by ne-fix (detection guard skips correct-order GGUFs)