### PR TITLE
fix(model-mgr): create cache dir before downloading

### DIFF
--- a/examples/cli/model_mgr.cpp
+++ b/examples/cli/model_mgr.cpp
@@ -1051,6 +1051,15 @@ static bool download_file(const std::string & source_url, const std::string & de
 #else
     std::string tmp = dest_path + ".tmp";
 
+    // Ensure the destination directory exists — curl/wget will not create it,
+    // and a missing cache dir otherwise fails with an opaque "No such file or
+    // directory" while writing the .tmp.
+    {
+        std::error_code mkdir_ec;
+        std::filesystem::path parent = std::filesystem::path(dest_path).parent_path();
+        if (!parent.empty()) std::filesystem::create_directories(parent, mkdir_ec);
+    }
+
     // Resume-aware: if a previous attempt left a partial .tmp, log the
     // recovery and pass `-C -` / `-c` to curl / wget so we resume from
     // there instead of starting over. Hours of bandwidth saved on flaky


### PR DESCRIPTION
## Problem
`download_file()` writes to `<cache>/<file>.tmp` without ensuring the cache directory exists. On a fresh machine (or with `CRISPEMBED_CACHE_DIR` set to a not-yet-created path), curl/wget fail with an opaque:
```
Warning: <cache>/<file>.gguf.tmp: No such file or directory
curl: (56) Failure writing output to destination
```
and `resolve_model(..., auto_download=True)` raises `Could not resolve model`.

## Fix
Create the destination's parent directory (`std::filesystem::create_directories`) at the start of `download_file()`, before invoking curl/wget.

Found while integrating CrispEmbed into a downstream tool — first-use auto-download failed until the cache dir was created by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)