### PR TITLE
fix(clip_text): CLIP BPE word-boundary tokenizer (</w> end-of-word)

### DIFF
--- a/src/clip_text_embed.cpp
+++ b/src/clip_text_embed.cpp
@@ -181,7 +181,8 @@ bool load(context ** out, const char * path, int n_threads) {
         ctx->sp_tokenizer.load(vocab, scores, -1, ctx->eos_id, 2, 0, ctx->max_pos);
         fprintf(stderr, "clip_text: SentencePiece tokenizer loaded (%zu vocab)\n", vocab.size());
     } else if (!vocab.empty() && !merges.empty()) {
-        ctx->bpe_tokenizer.load(vocab, merges, ctx->eos_id, ctx->eos_id, -1, ctx->bos_id, false, ctx->max_pos);
+        ctx->bpe_tokenizer.load(vocab, merges, ctx->eos_id, ctx->eos_id, -1, ctx->bos_id, false, ctx->max_pos,
+                                /*spm_dummy_prefix=*/false, /*clip_style=*/true);
         fprintf(stderr, "clip_text: BPE tokenizer loaded (%zu vocab, %zu merges)\n", vocab.size(), merges.size());
     } else {
         fprintf(stderr, "clip_text: WARNING — no tokenizer in GGUF\n");

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -109,9 +109,11 @@ private:
 };
 
 // BPE tokenizer for decoder embedding models.
-// Supports two modes:
+// Supports three modes:
 //   GPT-2 style (Qwen3): byte-level encoding with Ġ space marker
 //   SentencePiece style (Gemma): ▁ space marker, BOS/EOS tokens
+//   CLIP style (OpenAI CLIP text): lowercase + whitespace-clean + regex
+//     pre-tokenize + byte-level encoding with </w> end-of-word suffix
 class BPETokenizer {
 public:
     bool load(const std::vector<std::string> & vocab, const std::vector<std::string> & merges, int eos_id, int pad_id,
@@ -119,7 +121,8 @@ public:
               int bos_id = -1,        // -1 = no BOS
               bool spm_style = false, // true for SentencePiece BPE (Gemma)
               int max_length = 8192,
-              bool spm_dummy_prefix = false); // add_dummy_prefix (ERNIE/SPM)
+              bool spm_dummy_prefix = false, // add_dummy_prefix (ERNIE/SPM)
+              bool clip_style = false);      // true for OpenAI CLIP text BPE (</w> end-of-word)
 
     embed_tokens encode(const std::string & text) const;
 
@@ -139,8 +142,22 @@ private:
     int bos_id_ = -1;               // BOS token (-1 = none)
     bool spm_style_ = false;        // SentencePiece BPE mode
     bool spm_dummy_prefix_ = false; // SentencePiece add_dummy_prefix
+    bool clip_style_ = false;       // OpenAI CLIP text BPE (</w> end-of-word suffix)
     int max_length_ = 8192;
 
     // SentencePiece BPE: merge-based tokenization on ▁-prefixed text
     std::vector<int32_t> bpe_merge(const std::string & text) const;
+
+    // Rank-merge a list of initial symbols in place (shared by bpe_merge and
+    // the CLIP path). Uses merge_rank_ with an O(N log N) priority queue.
+    void merge_symbols(std::vector<std::string> & symbols) const;
+
+    // OpenAI CLIP text pre-tokenizer: lowercase + whitespace-clean +
+    // regex split (contractions / letter runs / single digits / punctuation
+    // runs). Returns raw-byte pre-tokens (before byte-level encoding).
+    std::vector<std::string> clip_pretokenize(const std::string & text) const;
+
+    // Byte-encode one CLIP pre-token, append the </w> end-of-word marker to
+    // the final symbol, rank-merge, and append the resulting vocab IDs.
+    void clip_bpe_word(const std::string & pretoken, std::vector<int32_t> & out) const;
 };

--- a/src/tokenizer_bpe.cpp
+++ b/src/tokenizer_bpe.cpp
@@ -1,8 +1,10 @@
 // tokenizer_bpe.cpp — BPE tokenizer for decoder models.
 //
-// Two modes:
+// Three modes:
 // - GPT-2 byte-level BPE (Qwen3): uses core_bpe from CrispASR
 // - SentencePiece BPE (Gemma): ▁ space marker, standard BPE merges
+// - CLIP text BPE (OpenAI CLIP): lowercase + whitespace-clean + regex
+//   pre-tokenize + byte-level encode + </w> end-of-word suffix
 
 #include "tokenizer.h"
 #include "core/bpe.h"
@@ -15,7 +17,8 @@
 #include <vector>
 
 bool BPETokenizer::load(const std::vector<std::string> & vocab, const std::vector<std::string> & merges, int eos_id,
-                        int pad_id, int suffix_id, int bos_id, bool spm_style, int max_length, bool spm_dummy_prefix) {
+                        int pad_id, int suffix_id, int bos_id, bool spm_style, int max_length, bool spm_dummy_prefix,
+                        bool clip_style) {
     id_to_token_ = vocab;
     token_to_id_.clear();
     token_to_id_.reserve(vocab.size());
@@ -35,8 +38,57 @@ bool BPETokenizer::load(const std::vector<std::string> & vocab, const std::vecto
     bos_id_ = bos_id;
     spm_style_ = spm_style;
     spm_dummy_prefix_ = spm_dummy_prefix;
+    clip_style_ = clip_style;
     max_length_ = max_length;
     return !vocab.empty();
+}
+
+// Rank-merge a list of initial symbols in place. Priority-queue BPE:
+// O(N log N) instead of O(N²). Symbol identity uses "left right" string
+// concatenation to match the textual merge table.
+void BPETokenizer::merge_symbols(std::vector<std::string> & symbols) const {
+    if (symbols.size() < 2) return;
+
+    struct Node {
+        std::string text;
+        int prev, next;
+    };
+    int n = (int)symbols.size();
+    std::vector<Node> nodes(n);
+    for (int i = 0; i < n; i++) {
+        nodes[i].text = std::move(symbols[i]);
+        nodes[i].prev = i - 1;
+        nodes[i].next = i < n - 1 ? i + 1 : -1;
+    }
+    using PQE = std::pair<int, int>;
+    auto cmp = [](const PQE & a, const PQE & b) { return a.first > b.first; };
+    std::priority_queue<PQE, std::vector<PQE>, decltype(cmp)> pq(cmp);
+    auto try_add = [&](int i) {
+        int j = nodes[i].next;
+        if (j < 0) return;
+        std::string pair = nodes[i].text + " " + nodes[j].text;
+        auto it = merge_rank_.find(pair);
+        if (it != merge_rank_.end()) pq.push({ it->second, i });
+    };
+    for (int i = 0; i < n; i++) try_add(i);
+    while (!pq.empty()) {
+        auto [rank, left] = pq.top();
+        pq.pop();
+        int right = nodes[left].next;
+        if (right < 0) continue;
+        std::string pair = nodes[left].text + " " + nodes[right].text;
+        auto it = merge_rank_.find(pair);
+        if (it == merge_rank_.end() || it->second != rank) continue;
+        nodes[left].text += nodes[right].text;
+        nodes[left].next = nodes[right].next;
+        if (nodes[right].next >= 0) nodes[nodes[right].next].prev = left;
+        nodes[right].next = -1;
+        nodes[right].prev = -1;
+        if (nodes[left].prev >= 0) try_add(nodes[left].prev);
+        try_add(left);
+    }
+    symbols.clear();
+    for (int i = 0; i >= 0; i = nodes[i].next) symbols.push_back(nodes[i].text);
 }
 
 // SentencePiece-style BPE: split into initial tokens, then merge by rank.
@@ -62,49 +114,7 @@ std::vector<int32_t> BPETokenizer::bpe_merge(const std::string & text) const {
         i += len;
     }
 
-    // Priority-queue BPE: O(N log N) instead of O(N²)
-    if (symbols.size() >= 2) {
-        struct Node {
-            std::string text;
-            int prev, next;
-        };
-        int n = (int)symbols.size();
-        std::vector<Node> nodes(n);
-        for (int i = 0; i < n; i++) {
-            nodes[i].text = std::move(symbols[i]);
-            nodes[i].prev = i - 1;
-            nodes[i].next = i < n - 1 ? i + 1 : -1;
-        }
-        using PQE = std::pair<int, int>;
-        auto cmp = [](const PQE & a, const PQE & b) { return a.first > b.first; };
-        std::priority_queue<PQE, std::vector<PQE>, decltype(cmp)> pq(cmp);
-        auto try_add = [&](int i) {
-            int j = nodes[i].next;
-            if (j < 0) return;
-            std::string pair = nodes[i].text + " " + nodes[j].text;
-            auto it = merge_rank_.find(pair);
-            if (it != merge_rank_.end()) pq.push({ it->second, i });
-        };
-        for (int i = 0; i < n; i++) try_add(i);
-        while (!pq.empty()) {
-            auto [rank, left] = pq.top();
-            pq.pop();
-            int right = nodes[left].next;
-            if (right < 0) continue;
-            std::string pair = nodes[left].text + " " + nodes[right].text;
-            auto it = merge_rank_.find(pair);
-            if (it == merge_rank_.end() || it->second != rank) continue;
-            nodes[left].text += nodes[right].text;
-            nodes[left].next = nodes[right].next;
-            if (nodes[right].next >= 0) nodes[nodes[right].next].prev = left;
-            nodes[right].next = -1;
-            nodes[right].prev = -1;
-            if (nodes[left].prev >= 0) try_add(nodes[left].prev);
-            try_add(left);
-        }
-        symbols.clear();
-        for (int i = 0; i >= 0; i = nodes[i].next) symbols.push_back(nodes[i].text);
-    }
+    merge_symbols(symbols);
 
     // Convert symbols to token IDs
     std::vector<int32_t> ids;
@@ -128,10 +138,125 @@ std::vector<int32_t> BPETokenizer::bpe_merge(const std::string & text) const {
     return ids;
 }
 
+namespace {
+// UTF-8 codepoint length from a leading byte (malformed → 1 for progress).
+inline size_t clip_utf8_len(unsigned char c) {
+    if (c < 0x80) return 1;
+    if ((c & 0xE0) == 0xC0) return 2;
+    if ((c & 0xF0) == 0xE0) return 3;
+    if ((c & 0xF8) == 0xF0) return 4;
+    return 1;
+}
+inline bool clip_is_space(unsigned char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+inline bool clip_is_digit(unsigned char c) {
+    return c >= '0' && c <= '9';
+}
+// CLIP's regex \p{L}: ASCII letters plus any non-ASCII byte (a multi-byte
+// UTF-8 letter such as é/ï/CJK). Rare non-ASCII punctuation is approximated
+// as a letter, harmless for CLIP's short-caption domain.
+inline bool clip_is_letter(unsigned char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= 0x80);
+}
+} // namespace
+
+// OpenAI CLIP text pre-tokenizer. Reproduces:
+//   whitespace_clean(basic_clean(text)).lower() then re.findall(pat, text)
+// with pat = 's|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+
+// (single space collapse + strip are implicit — whitespace is just skipped).
+std::vector<std::string> BPETokenizer::clip_pretokenize(const std::string & text) const {
+    std::string s;
+    s.reserve(text.size());
+    for (unsigned char c : text) s.push_back((c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : (char)c);
+
+    std::vector<std::string> out;
+    const size_t n = s.size();
+    size_t i = 0;
+    while (i < n) {
+        unsigned char c = (unsigned char)s[i];
+        if (clip_is_space(c)) {
+            i++;
+            continue;
+        }
+        // Contractions: 're 've 'll (two-letter) then 's 't 'm 'd (one-letter).
+        if (c == '\'' && i + 1 < n) {
+            if (i + 2 < n) {
+                std::string two = s.substr(i + 1, 2);
+                if (two == "re" || two == "ve" || two == "ll") {
+                    out.push_back(s.substr(i, 3));
+                    i += 3;
+                    continue;
+                }
+            }
+            unsigned char d = (unsigned char)s[i + 1];
+            if (d == 's' || d == 't' || d == 'm' || d == 'd') {
+                out.push_back(s.substr(i, 2));
+                i += 2;
+                continue;
+            }
+        }
+        if (clip_is_letter(c)) { // [\p{L}]+
+            size_t j = i;
+            while (j < n && clip_is_letter((unsigned char)s[j])) j += clip_utf8_len((unsigned char)s[j]);
+            out.push_back(s.substr(i, j - i));
+            i = j;
+            continue;
+        }
+        if (clip_is_digit(c)) { // [\p{N}] — a single digit per token
+            out.push_back(s.substr(i, 1));
+            i++;
+            continue;
+        }
+        // [^\s\p{L}\p{N}]+ — a run of punctuation/symbols.
+        size_t j = i;
+        while (j < n) {
+            unsigned char e = (unsigned char)s[j];
+            if (clip_is_space(e) || clip_is_letter(e) || clip_is_digit(e)) break;
+            j++;
+        }
+        out.push_back(s.substr(i, j - i));
+        i = j;
+    }
+    return out;
+}
+
+// Byte-level encode one CLIP pre-token, append </w> to its final symbol,
+// rank-merge, and append the resulting vocab IDs.
+void BPETokenizer::clip_bpe_word(const std::string & pretoken, std::vector<int32_t> & out) const {
+    if (pretoken.empty()) return;
+    std::string enc = core_bpe::bytes_to_unicode(pretoken.data(), pretoken.size());
+
+    std::vector<std::string> symbols;
+    size_t i = 0;
+    while (i < enc.size()) {
+        size_t len = std::min(clip_utf8_len((unsigned char)enc[i]), enc.size() - i);
+        symbols.emplace_back(enc, i, len);
+        i += len;
+    }
+    if (symbols.empty()) return;
+    symbols.back() += "</w>"; // end-of-word marker on the last character
+
+    merge_symbols(symbols);
+
+    for (const auto & sym : symbols) {
+        auto it = token_to_id_.find(sym);
+        if (it != token_to_id_.end()) out.push_back(it->second);
+        // Unknown symbols cannot occur with a complete CLIP vocab (every
+        // byte-unicode char exists both plain and with </w>); skip if so.
+    }
+}
+
 embed_tokens BPETokenizer::encode(const std::string & text) const {
     std::vector<int32_t> ids;
 
-    if (spm_style_) {
+    if (clip_style_) {
+        // OpenAI CLIP text: regex pre-tokenize + byte-level BPE with </w>.
+        for (const auto & pt : clip_pretokenize(text)) clip_bpe_word(pt, ids);
+        // Wrap with <|startoftext|> (BOS) and <|endoftext|> (EOS).
+        if (bos_id_ >= 0) ids.insert(ids.begin(), bos_id_);
+        if (eos_id_ >= 0) ids.push_back(eos_id_);
+    } else if (spm_style_) {
         // SentencePiece normalization: optional add_dummy_prefix (a leading
         // space → ▁ at the very start, used by ERNIE-4.5/PaddleOCR-VL), then
         // every space → ▁ (U+2581). Newlines and other bytes fall through to

--- a/tests/gen_clip_tokenizer_reference.py
+++ b/tests/gen_clip_tokenizer_reference.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate a HuggingFace CLIP tokenizer reference for test_clip_tokenizer_parity.
+
+Dumps the CLIP text vocab + merges and the expected token IDs for a fixed set
+of probe strings, so the C++ harness can replay them and assert exact parity
+with `CLIPTokenizerFast` (the ground truth this fix was validated against).
+
+    python tests/gen_clip_tokenizer_reference.py \
+        --model openai/clip-vit-base-patch32 \
+        --out-dir /tmp/clip-tok-ref
+
+Writes vocab.tsv (one token per id, in id order), merges.tsv (one "a b" merge
+per line, rank order) and expected.tsv ("<text>\\t<comma-separated ids>").
+Any CLIP checkpoint works — they share the same 49408-entry BPE vocab.
+"""
+import argparse
+from pathlib import Path
+
+
+# Probe strings covering the tokenizer's tricky cases. Keep in sync with the
+# table in test_clip_tokenizer_parity.cpp is NOT required — the harness reads
+# expected.tsv — but do keep them representative.
+PROBES = [
+    "hello",
+    "a photo of a fox",  # the handover's decisive example (49406 320 1125 539 320 3240 49407)
+    "a photo of a cat",
+    "Hello World!",  # lowercasing + punctuation run
+    "don't stop",  # contraction split
+    "CVPR2024 paper",  # letter-run merges + per-digit split
+    "naïve café",  # byte-level non-ASCII
+    "hello  world",  # whitespace collapse
+    "  leading and trailing  ",  # strip
+    "3.14 is pi",
+    "e-mail: test@example.com",
+    "",  # empty -> BOS/EOS only
+    "the QUICK brown Fox",
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="openai/clip-vit-base-patch32")
+    ap.add_argument("--out-dir", required=True)
+    args = ap.parse_args()
+
+    import json
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    tj_path = Path(tok.name_or_path) / "tokenizer.json"
+    if tj_path.exists():
+        model = json.load(open(tj_path))["model"]
+        vocab, merges = model["vocab"], model["merges"]
+    else:
+        vocab = tok.get_vocab()
+        merges = [f"{a} {b}" for (a, b) in sorted(tok.bpe_ranks, key=tok.bpe_ranks.get)]
+
+    vsize = max(vocab.values()) + 1
+    tokens = [""] * vsize
+    for t, i in vocab.items():
+        if 0 <= i < vsize:
+            tokens[i] = t
+    mlist = [m if isinstance(m, str) else f"{m[0]} {m[1]}" for m in merges]
+
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    with open(out / "vocab.tsv", "w") as f:
+        for t in tokens:
+            f.write(t.replace("\n", "\\n") + "\n")
+    with open(out / "merges.tsv", "w") as f:
+        for m in mlist:
+            f.write(m + "\n")
+    with open(out / "expected.tsv", "w") as f:
+        for t in PROBES:
+            ids = tok(t, add_special_tokens=True)["input_ids"]
+            esc = t.replace("\t", "\\t").replace("\n", "\\n")
+            f.write(esc + "\t" + ",".join(map(str, ids)) + "\n")
+
+    print(f"bos={tok.bos_token_id} eos={tok.eos_token_id} "
+          f"vocab={len(tokens)} merges={len(mlist)} probes={len(PROBES)} -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clip_tokenizer_parity.cpp
+++ b/tests/test_clip_tokenizer_parity.cpp
@@ -1,0 +1,108 @@
+// tests/test_clip_tokenizer_parity.cpp — CLIP BPE tokenizer parity harness.
+//
+// Replays HuggingFace CLIPTokenizerFast token IDs against CrispEmbed's
+// clip_style BPETokenizer path and asserts an exact match. This guards the
+// CLIP `</w>` end-of-word word-boundary tokenizer (fixed in
+// "fix(clip_text): CLIP BPE word-boundary tokenizer"): the old code routed
+// CLIP through the GPT-2 byte-level path, emitting a standalone `Ġ` (220)
+// space token instead of `</w>`, so every token id was wrong and text-image
+// cosine dropped to ~0.79.
+//
+// Self-contained — links only against src/tokenizer_bpe.cpp (no ggml/GGUF).
+// Generate the reference files from any CLIP checkpoint first:
+//
+//   python tests/gen_clip_tokenizer_reference.py \
+//       --model openai/clip-vit-base-patch32 --out-dir /tmp/clip-tok-ref
+//
+// Then build and run:
+//
+//   c++ -std=c++17 -O1 -Isrc tests/test_clip_tokenizer_parity.cpp \
+//       src/tokenizer_bpe.cpp -o /tmp/test-clip-tok
+//   /tmp/test-clip-tok /tmp/clip-tok-ref/{vocab,merges,expected}.tsv
+//
+// Exit code 0 == all probes match HF; non-zero == a tokenizer regression.
+
+#include "tokenizer.h"
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+static std::vector<std::string> read_lines(const char * path) {
+    std::vector<std::string> out;
+    std::ifstream f(path);
+    if (!f) {
+        fprintf(stderr, "cannot open %s\n", path);
+        return out;
+    }
+    std::string line;
+    while (std::getline(f, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        out.push_back(line);
+    }
+    return out;
+}
+
+// Unescape the \n and \t written by the generator.
+static std::string unescape(const std::string & s) {
+    std::string out;
+    for (size_t i = 0; i < s.size(); i++) {
+        if (s[i] == '\\' && i + 1 < s.size()) {
+            if (s[i + 1] == 'n') { out.push_back('\n'); i++; continue; }
+            if (s[i + 1] == 't') { out.push_back('\t'); i++; continue; }
+        }
+        out.push_back(s[i]);
+    }
+    return out;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s vocab.tsv merges.tsv expected.tsv\n", argv[0]);
+        return 2;
+    }
+    auto vocab = read_lines(argv[1]);
+    auto merges = read_lines(argv[2]);
+    auto expected = read_lines(argv[3]);
+    if (vocab.empty() || merges.empty() || expected.empty()) {
+        fprintf(stderr, "missing/empty reference files — run gen_clip_tokenizer_reference.py\n");
+        return 2;
+    }
+
+    BPETokenizer tok;
+    // CLIP: eos=49407, pad=49407, suffix=-1, bos=49406, spm=false, max=77,
+    // spm_dummy_prefix=false, clip_style=true.
+    tok.load(vocab, merges, 49407, 49407, -1, 49406, false, 77, false, true);
+
+    int pass = 0, fail = 0;
+    for (const auto & row : expected) {
+        auto tab = row.find('\t');
+        if (tab == std::string::npos) continue;
+        std::string text = unescape(row.substr(0, tab));
+
+        std::vector<int> exp;
+        std::stringstream ss(row.substr(tab + 1));
+        std::string num;
+        while (std::getline(ss, num, ',')) {
+            if (!num.empty()) exp.push_back(std::stoi(num));
+        }
+
+        embed_tokens got = tok.encode(text);
+        bool ok = got.ids.size() == exp.size();
+        for (size_t i = 0; ok && i < exp.size(); i++) ok = got.ids[i] == exp[i];
+
+        printf("%s '%s'\n", ok ? "PASS" : "FAIL", row.substr(0, tab).c_str());
+        if (!ok) {
+            printf("   expected:");
+            for (int x : exp) printf(" %d", x);
+            printf("\n   got:     ");
+            for (int x : got.ids) printf(" %d", x);
+            printf("\n");
+        }
+        ok ? pass++ : fail++;
+    }
+    printf("\n=== %d passed, %d failed ===\n", pass, fail);
+    return fail ? 1 : 0;
+}


### PR DESCRIPTION
## Problem
`crispembed_clip_text_encode` returned embeddings at only **cos 0.79** vs the HF `CLIPTextModel.get_text_features` reference — a pre-existing tokenizer bug. The CLIP text encoder routed its BPE through the GPT-2 byte-level path (`core_bpe::tokenize_simple`), which uses the leading-space (`Ġ`) word-boundary convention and no end-of-word marker. It emitted a standalone `220` (`Ġ`) token between every word instead of appending `</w>` to each word, so every token id was wrong (only BOS/EOS matched).

Decisive example — `"a photo of a fox"`:
```
HF CLIPTokenizer : 49406 320 1125 539 320 3240 49407          (7 tokens)
old clip_text    : 49406 64 220 1153 220 684 220 64 220 5007 49407  (11 tokens)
```

## Fix
Add a `clip_style` mode to `BPETokenizer` reproducing `CLIPTokenizer`:
- lowercase + implicit whitespace collapse/strip
- regex pre-tokenize: `'s|'t|'re|'ve|'m|'ll|'d | [\p{L}]+ | [\p{N}] | [^\s\p{L}\p{N}]+`
- byte-level encode + `</w>` on the final symbol, then `merge_rank_` merges
- wrap with `<|startoftext|>` / `<|endoftext|>`

Factors the priority-queue merge out of `bpe_merge` into a shared `merge_symbols` helper. `clip_text` passes `clip_style=true` (CLIP-only branch; SigLIP stays on SentencePiece). The new `load` param defaults to `false`, so the other three callers are unaffected.

## Verification
- **Tokenizer parity**: exact token-ID match with HF `CLIPTokenizerFast` (ViT-B/32 vocab) across 13 probes — lowercasing, `</w>` boundaries, contractions (`don't`), per-digit splitting (`CVPR2024`, `3.14`), byte-level non-ASCII (`naïve café`), punctuation runs, whitespace collapse, empty string. **13/13.**
- **End-to-end**: `test-clip-text-diff` vs the HF AutoModel reference goes from **cos 0.791656 → 1.000000** (max_abs 0.0).
- Full in-tree build compiles + links; formatted with clang-format 18.1.8.

Adds `tests/test_clip_tokenizer_parity.cpp` + `tests/gen_clip_tokenizer_reference.py` as a standalone regression guard (links only against `tokenizer_bpe.cpp`, no ggml/GGUF).