### PR TITLE
chore(gitignore): ignore tmp/ (prevent tessdata bloat recurrence)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,9 @@ build-embed-wasm/
 .models-tmp/
 .ds-blueprints/
 
+# scratch/temp dir — was accidentally committed once (Tesseract tessdata,
+# ~113 MB of pack bloat purged from history); never track it again
+tmp/
+
 # scan_cleanup benchmark output
 scan-bench/


### PR DESCRIPTION
Adds `tmp/` to .gitignore. The Tesseract `tmp/tessdata_best/*.traineddata` files (~113 MB) were accidentally committed once and are being purged from pack history; this stops it recurring.