### PR TITLE
build(ggml): move the pin to sync/upstream-v0.17 (0.10.2 → 0.17.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ggml"]
 	path = ggml
 	url = https://github.com/CrispStrobe/ggml.git
-	branch = crispstrobe-ops
+	branch = sync/upstream-v0.17

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -94,9 +94,12 @@ if [ "$WEBGPU" = "ON" ]; then
     # + a warning when the encoder silently skips an unsupported op. All
     # validated in-browser via ggml test-backend-ops (see
     # tests/wasm-browser/README note + LEARNINGS). Idempotent apply.
-    # NOTE (2026-07): these webgpu ops now live in the pinned ggml submodule
-    # (CrispStrobe/ggml @ crispstrobe-ops = v0.10.2 + our ops), so the old
-    # build-time patch is no longer applied. Kept in patches/ for provenance.
+    # NOTE (2026-07): these webgpu ops now live in the pinned ggml submodule,
+    # so the old build-time patch is no longer applied. Kept in patches/ for
+    # provenance. (2026-08: the pin moved from crispstrobe-ops = v0.10.2 + our
+    # ops to sync/upstream-v0.17 = v0.17.0, where the same ops are already
+    # forward-ported — same fork, newer base. This matches the ggml CrispASR
+    # ships, so an app bundling both libraries has one ABI, not two.)
     echo "[INFO] ggml-webgpu ops (NORM/arange/pool2d/conv_transpose_2d + upstreamed im2col/upscale) are baked into the pinned CrispStrobe/ggml submodule"
     # Experimental: ggml-webgpu links the emdawnwebgpu port and adds
     # -sASYNCIFY itself (INTERFACE link options). Separate output dir so all

--- a/flutter/crispembed/ios/crispembed.podspec
+++ b/flutter/crispembed/ios/crispembed.podspec
@@ -1,6 +1,9 @@
+# Derived, not hardcoded — see the note in macos/crispembed.podspec: this
+# version is also the release tag prepare_command fetches the prebuilt libs
+# from, and the literal had drifted three releases behind.
 Pod::Spec.new do |s|
   s.name             = 'crispembed'
-  s.version          = '0.16.0'
+  s.version          = File.read(File.join(__dir__, '..', 'pubspec.yaml'))[/^version:\s*([0-9][^\s+]*)/, 1]
   s.summary          = 'CrispEmbed on-device inference — embeddings + math OCR via ggml.'
   s.homepage         = 'https://github.com/CrispStrobe/CrispEmbed'
   s.license          = { :type => 'MIT' }

--- a/flutter/crispembed/macos/crispembed.podspec
+++ b/flutter/crispembed/macos/crispembed.podspec
@@ -1,6 +1,13 @@
+# The pod version doubles as the release tag the prebuilt libs are fetched
+# from (see prepare_command below), so a hardcoded literal here silently
+# pins every `pod install` to an old release: it sat at 0.16.0 while the
+# project shipped 0.17.0/0.17.1/0.17.2, and macOS/iOS kept downloading the
+# July libs. Derive it from the plugin's pubspec.yaml — the one file that is
+# always shipped next to this podspec, on pub.dev and in a repo checkout
+# alike — so bumping the release bumps this automatically.
 Pod::Spec.new do |s|
   s.name             = 'crispembed'
-  s.version          = '0.16.0'
+  s.version          = File.read(File.join(__dir__, '..', 'pubspec.yaml'))[/^version:\s*([0-9][^\s+]*)/, 1]
   s.summary          = 'CrispEmbed on-device inference — embeddings + math OCR via ggml.'
   s.homepage         = 'https://github.com/CrispStrobe/CrispEmbed'
   s.license          = { :type => 'MIT' }


### PR DESCRIPTION
## Why

CrispASR and CrispEmbed use the **same** ggml fork, but CrispEmbed tracked the older branch:

| | branch | ggml |
|---|---|---|
| CrispEmbed (before) | `crispstrobe-ops` @ `0714117d` | 0.10.2 |
| CrispASR (v0.8.25) | `sync/upstream-v0.17` @ `a0f7289d` | **0.17.0** |

That is fine until something bundles both. CrisperWeaver does, and on macOS the two sets land in one flat `Contents/Frameworks/` claiming the same `@rpath/libggml*.0.dylib` install names — only one can win, so `libcrispembed` built against 0.10.2 was being loaded against 0.17.0 at runtime. Matching the pin removes the skew at the source rather than relying on the two staying compatible.

## What this is not

Not a port. The CrispStrobe ops are **already forward-ported** on `sync/upstream-v0.17` — `GGML_OP_COL2IM_1D`, `GGML_OP_NORM_AFFINE`, `GGML_OP_AA_SNAKE_BETA`, the siglu variants, and the WebGPU shaders (`arange`, `pool2d`, `conv_transpose_2d`, `row_norm`/NORM). Each verified present at `a0f7289d`. Same fork, newer base, so this is two lines: `.gitmodules` and the gitlink.

## Verification (macos-arm64, release flags: Metal + embedded library, BLAS=Apple, NATIVE=OFF)

- Full tree builds **100%, exit 0, zero errors**. The 7 warnings are all pre-existing (enum switch, `fabsf`, `sprintf`/`setFastMathEnabled` deprecations).
- `test-core-cpu-ops` **172/172 passed**; `test-backend-smoke` `correct=1` on Metal.
- `LFM2.5-Embedding-350M-Q8_0` embeddings **unchanged to 4 decimals** vs the 0.10.2-built library (related `0.5812`, unrelated `0.0542`).

Not covered locally: CUDA/Vulkan/WebGPU legs and the WASM build — left to CI.

## Second commit: podspec version

Found while tracing why the vendored dylibs were from July. `prepare_command` fetches from `releases/download/v#{s.version}/`, so the hardcoded `s.version = '0.16.0'` decided which release every `pod install` pulled — it stayed at 0.16.0 through v0.17.0/0.17.1/0.17.2, silently. Now derived from `pubspec.yaml`, which ships next to the podspec both on pub.dev and in a checkout.

## After merge

Every existing release — including today's v0.17.2 — still records the old gitlink, so **no published tarball contains ggml 0.17.0 yet**. A new release (bump `VERSION` + the plugin `pubspec.yaml`) is needed before consumers see this; then CrisperWeaver moves `CRISPEMBED_REF` off v0.16.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)