### PR TITLE
gguf: add release_weight_buffer, keyed to the buffer rather than the load

### DIFF
--- a/src/core/gguf_loader.cpp
+++ b/src/core/gguf_loader.cpp
@@ -7,6 +7,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <map>
+#include <mutex>
 
 #if defined(_WIN32)
 #include <io.h>
@@ -201,8 +203,9 @@ std::vector<uint8_t> kv_u8_array(gguf_context * gctx, const char * key) {
 
 namespace {
 
-// Platform unmap, shared by MappedFile's destructor and free_weights() (the
-// no-copy path transfers the mapping into WeightLoad, which unmaps on free).
+// Platform unmap, shared by MappedFile's destructor and release_weight_buffer()
+// (the no-copy path transfers the mapping to the backend buffer, which unmaps
+// when that buffer is released).
 void core_unmap(void * base, size_t size) {
     if (!base) return;
 #if defined(__EMSCRIPTEN__)
@@ -213,6 +216,44 @@ void core_unmap(void * base, size_t size) {
 #else
     ::munmap(base, size);
 #endif
+}
+
+// Which host mapping belongs to which backend buffer.
+//
+// On the no-copy path the backend buffer is a view onto pages the backend does
+// not own: ggml_backend_dev_buffer_from_host_ptr has no deallocator parameter,
+// so freeing the buffer releases the view and nothing else. WeightLoad carries
+// mmap_addr/mmap_len for the caller that keeps the whole struct, but a caller
+// that moves `buf` into its model and lets the WeightLoad die drops the only
+// record of the mapping — and eleven of the models in src/ tear down that way.
+// Keying the region to the buffer instead means the mapping is released by
+// whoever releases the buffer, whichever of the two shapes the caller uses.
+struct mmap_region {
+    void * base = nullptr;
+    size_t size = 0;
+};
+
+std::mutex g_buf_mmap_mu;
+std::map<ggml_backend_buffer_t, mmap_region> g_buf_mmap;
+
+void register_buf_mmap(ggml_backend_buffer_t buf, void * base, size_t size) {
+    std::lock_guard<std::mutex> lk(g_buf_mmap_mu);
+    g_buf_mmap[buf] = { base, size };
+}
+
+// Look the region up and remove the entry in one critical section. A lookup
+// followed by a separate erase would let a second release of the same buffer
+// read the entry before the first erased it and unmap twice; it would also
+// race a concurrent load whose fresh buffer landed on the same address after
+// the free. A default-constructed region means no entry, which is the ordinary
+// case — the copy path maps nothing that outlives the load.
+mmap_region take_buf_mmap(ggml_backend_buffer_t buf) {
+    std::lock_guard<std::mutex> lk(g_buf_mmap_mu);
+    auto it = g_buf_mmap.find(buf);
+    if (it == g_buf_mmap.end()) return mmap_region{};
+    const mmap_region r = it->second;
+    g_buf_mmap.erase(it);
+    return r;
 }
 
 // Read a file slice into a backend tensor. Uses mmap on POSIX; falls back
@@ -350,7 +391,10 @@ bool load_weights(const char * path, ggml_backend_t backend, const char * model_
                     out.mmap_addr = mf.base;
                     out.mmap_len = mf.size;
                     out.used_mmap = true;
-                    mf.release(); // WeightLoad now owns the mapping
+                    // The buffer owns the mapping from here; the WeightLoad
+                    // fields above are a record of it, not a second owner.
+                    register_buf_mmap(buf, mf.base, mf.size);
+                    mf.release();
                     gguf_free(gctx);
                     return true;
                 }
@@ -630,23 +674,30 @@ bool load_weights_split(const char * path, ggml_backend_t gpu_backend, ggml_back
     return true;
 }
 
+void release_weight_buffer(ggml_backend_buffer_t & buf) {
+    if (!buf) return;
+    // Take the entry before the free, not after: between a free and a later
+    // erase, a concurrent load could receive a new buffer at the same address
+    // and register it, and the erase would then drop a live mapping's record.
+    const mmap_region r = take_buf_mmap(buf);
+    // Free the buffer first. On the no-copy path it is a view onto these pages,
+    // so unmapping them while it is alive would leave the device addressing
+    // unmapped memory.
+    ggml_backend_buffer_free(buf);
+    buf = nullptr;
+    core_unmap(r.base, r.size);
+}
+
 void free_weights(WeightLoad & wl) {
-    if (wl.buf) {
-        ggml_backend_buffer_free(wl.buf); // no-copy buffer doesn't own the pages
-        wl.buf = nullptr;
-    }
-    if (wl.buf_cpu) {
-        ggml_backend_buffer_free(wl.buf_cpu);
-        wl.buf_cpu = nullptr;
-    }
-    for (auto * b : wl.split_bufs) ggml_backend_buffer_free(b);
+    release_weight_buffer(wl.buf);
+    release_weight_buffer(wl.buf_cpu);
+    for (auto * b : wl.split_bufs) release_weight_buffer(b);
     wl.split_bufs.clear();
-    if (wl.mmap_addr) { // unmap after the buffer is freed
-        core_unmap(wl.mmap_addr, wl.mmap_len);
-        wl.mmap_addr = nullptr;
-        wl.mmap_len = 0;
-        wl.used_mmap = false;
-    }
+    // The mapping was released with its buffer above; these fields are the
+    // caller-visible record of the load, so clear them without unmapping again.
+    wl.mmap_addr = nullptr;
+    wl.mmap_len = 0;
+    wl.used_mmap = false;
     if (wl.ctx) {
         ggml_free(wl.ctx);
         wl.ctx = nullptr;

--- a/src/core/gguf_loader.h
+++ b/src/core/gguf_loader.h
@@ -167,8 +167,37 @@ using IsGpuTensor = bool (*)(const char * tensor_name, void * user);
 bool load_weights_split(const char * path, ggml_backend_t gpu_backend, ggml_backend_t cpu_backend, IsGpuTensor is_gpu,
                         void * user, const char * model_tag, WeightLoad & out);
 
+// Free a backend buffer that came from one of this loader's weight-loading
+// entry points, releasing the host mmap behind it when there is one.
+//
+// USE THIS INSTEAD OF ggml_backend_buffer_free() FOR ANY BUFFER OBTAINED FROM
+// load_weights() / load_weights_split(), including after the buffer has been
+// moved into a model struct. On the no-copy path
+// (`load_weights(..., try_mmap=true)` on a device advertising
+// buffer_from_host_ptr) the backend buffer is a view onto a host mapping the
+// backend does not own — buffer_from_host_ptr has no deallocator parameter —
+// so freeing the buffer alone leaves the weight file mapped for the life of
+// the process. free_weights() reaches the same mapping through WeightLoad, but
+// only for a caller that still holds the whole struct; a caller that moved
+// `buf` into its model has this entry point and nothing else.
+//
+// Semantics:
+//   * A null handle is a no-op, and the caller's handle is nulled on return,
+//     so a second call cannot double-free or double-unmap.
+//   * A buffer with no recorded mapping is the ordinary case — the copy path
+//     maps nothing that outlives the load — and is released like any other
+//     backend buffer.
+//   * The backend buffer is freed before the region is unmapped, so a
+//     device-side view of the pages never outlives them.
+//
+// This is also the entry point CrispASR's shared `crisp_audio` source calls,
+// so the name and behaviour have to hold in both repos — see the cross-repo
+// contract note above.
+void release_weight_buffer(ggml_backend_buffer_t & buf);
+
 // Free a WeightLoad's resources. Call when the model is being destroyed
-// and the buffer/context are not held elsewhere.
+// and the buffer/context are not held elsewhere. Releases every buffer
+// through release_weight_buffer().
 void free_weights(WeightLoad & wl);
 
 // ---------------------------------------------------------------------------

--- a/tests/test_gguf_loader_mmap.cpp
+++ b/tests/test_gguf_loader_mmap.cpp
@@ -2,7 +2,8 @@
 // Builds a small GGUF, loads it both ways on the CPU backend (which advertises
 // buffer_from_host_ptr), and asserts the tensors are byte-identical and match
 // the values written. Validates the no-copy path is actually taken and that
-// free_weights() cleans up (incl. the mmap) without crashing.
+// free_weights() releases the mapping — asked of the kernel, not inferred from
+// the call returning.
 
 #include "core/gguf_loader.h"
 #include "core/clean_exit.h"
@@ -13,11 +14,68 @@
 
 #include <cmath>
 #include <cstdio>
+#include <climits>
 #include <cstring>
 #include <string>
 #include <vector>
 
+#if defined(__APPLE__)
+#include <libproc.h>
+#include <sys/proc_info.h>
+#include <unistd.h>
+#elif defined(__linux__)
+#include <fstream>
+#endif
+
 static const char * kPath = "/tmp/crispembed_test_loader_mmap.gguf";
+
+// The kernel names a region by its resolved path, so the comparison has to be
+// made against the same. On macOS /tmp is a symlink to /private/tmp, which is
+// enough on its own to make every region look like a stranger's.
+static std::string resolved_path(const char * path) {
+#if defined(_WIN32)
+    return std::string(path);
+#else
+    char buf[PATH_MAX];
+    return realpath(path, buf) ? std::string(buf) : std::string(path);
+#endif
+}
+
+// How many regions of this process are backed by `path`. The no-copy path keeps
+// the weight file mapped for the buffer's lifetime, so this is the exact way to
+// ask whether the mapping went away — no footprint threshold, nothing to settle.
+// Returns (size_t)-1 where the platform offers no region enumeration, which the
+// caller treats as "cannot assert here".
+static size_t count_regions_backed_by(const std::string & path) {
+#if defined(__APPLE__)
+    // PROC_PIDREGIONPATHINFO returns the region and its backing path in one
+    // record. proc_regionfilename() alone is not usable: asked about the base of
+    // an anonymous region it answers with the file of the next region above,
+    // counting an unrelated neighbour as a mapping of this file.
+    size_t n = 0;
+    uint64_t addr = 0;
+    for (;;) {
+        struct proc_regionwithpathinfo rpi;
+        if (proc_pidinfo(getpid(), PROC_PIDREGIONPATHINFO, addr, &rpi, sizeof(rpi)) != (int)sizeof(rpi)) break;
+        if (rpi.prp_vip.vip_path[0] != '\0' && path == rpi.prp_vip.vip_path) n++;
+        const uint64_t next = rpi.prp_prinfo.pri_address + rpi.prp_prinfo.pri_size;
+        if (next <= addr) break; // no forward progress; stop rather than spin
+        addr = next;
+    }
+    return n;
+#elif defined(__linux__)
+    size_t n = 0;
+    const size_t len = path.size();
+    std::ifstream maps("/proc/self/maps");
+    std::string line;
+    while (std::getline(maps, line))
+        if (line.size() > len && line.compare(line.size() - len, len, path) == 0) n++;
+    return n;
+#else
+    (void)path;
+    return (size_t)-1;
+#endif
+}
 
 static float expected(int i) {
     return sinf((float)i * 0.013f) + 0.5f;
@@ -101,8 +159,31 @@ static int crispembed_test_main() {
         if (!ok) fails++;
     }
 
+    // The mapping is keyed to the backend buffer, so free_weights reaches it
+    // through release_weight_buffer rather than through mw.mmap_addr. Check the
+    // kernel, not the field: a desync between where the region is registered
+    // and where it is taken would leave the file mapped and clear the field
+    // anyway.
+    const std::string kAbs = resolved_path(kPath);
+    const size_t mapped_before = count_regions_backed_by(kAbs);
     core_gguf::free_weights(cw);
-    core_gguf::free_weights(mw); // also unmaps
+    core_gguf::free_weights(mw);
+    if (mapped_before == (size_t)-1) {
+        printf("region enumeration unavailable on this platform — mapping release not asserted\n");
+    } else if (mapped_before < 1) {
+        // Positive control. Without it the zero below would also be satisfied
+        // by a load that never mapped the file in the first place.
+        fprintf(stderr, "FAIL: no-copy load left no mapping to release (found %zu regions)\n", mapped_before);
+        fails++;
+    } else {
+        const size_t mapped_after = count_regions_backed_by(kAbs);
+        printf("  weight file regions: %zu while loaded, %zu after free_weights\n", mapped_before, mapped_after);
+        if (mapped_after != 0) {
+            fprintf(stderr, "FAIL: free_weights left %zu mapping(s) of %s\n", mapped_after, kPath);
+            fails++;
+        }
+    }
+
     ggml_backend_free(backend);
     remove(kPath);
 


### PR DESCRIPTION
**This repo does not have the leak CrispStrobe/CrispASR#347 fixes.** Claude checked before writing anything, and the
answer is worth stating up front so this PR is read for what it is: a small API change to keep the
shared sources compiling, plus one latent hole closed on the way. Nothing here is a bug fix.

Three reasons CrispEmbed is not affected:

- **The no-copy path is opt-in.** `load_weights(..., try_mmap = false)` by default. Only two callers
  pass `true`, both behind an env switch: `deepseek_ocr2` (`DS_MMAP`) and `unlimited_ocr`
  (`UOCR_MMAP`).
- **Both of them keep the whole `WeightLoad`** (`ctx.model_wl`) and tear down through
  `free_weights`, which already freed the buffer and then unmapped.
- **The mapping is `PROT_READ | MAP_SHARED`** (`gguf_loader.cpp:302`; `PAGE_READONLY` +
  `FILE_MAP_READ` on Windows). Clean, droppable page cache — not the dirty `MAP_PRIVATE` +
  `PROT_READ|PROT_WRITE` pages that make the CrispASR case cost real memory.

### Why this is needed

CrispEmbed builds three shared libraries out of `../CrispASR` — `crisp_audio`, `crisp_punc` and
`crisp_lid`, wired up by the `CRISP_*_DIR` cache paths in the top-level `CMakeLists.txt`. Those
sources compile against **this** repo's `core/gguf_loader.h`, and CrispStrobe/CrispASR#347 routes every
weight-buffer teardown in them through a new `core_gguf::release_weight_buffer`.

So merging #347 without this breaks the CrispEmbed build. Verified rather than reasoned about — with
this commit reverted, any target that pulls those libraries in stops at:

```
../CrispASR/crisp_audio/src/audio_tower.cpp:692:16: error: no member named
    'release_weight_buffer' in namespace 'core_gguf'
../CrispASR/crisp_lid/src/lid_cld3.cpp:807:20: error: no member named
    'release_weight_buffer' in namespace 'core_gguf'
make[2]: *** [crisp_punc/CMakeFiles/crisp_punc.dir/all] Error 2
```

Four call sites in total across the three libraries — `crisp_audio/src/audio_tower.cpp:692`,
`crisp_lid/src/lid_cld3.cpp:807`, `crisp_punc/src/fireredpunc.cpp:908` and
`crisp_punc/src/pcs.cpp:1024`.

### What it does, and why not a stub

The narrow fix would be to declare `release_weight_buffer` as `ggml_backend_buffer_free` plus a
null-out. It would compile, and it would be correct for this repo *today*. I did not do that.

Upstream the function's contract is "release this buffer **and** whatever host mapping the loader
attached to it". A name that means that in one repo and something weaker in the other is exactly the
cross-repo drift the `CROSS-REPO TENSOR-MAP CONTRACT` note at the top of this header already exists
to prevent — the header records a run of commits spent recovering from the last round of it, and
`tests/test-copies-in-sync.cpp` compares paths within one checkout, so it structurally cannot see
this pair.

So the mapping is now keyed to the **backend buffer** as well, not only to the `WeightLoad`:

- `load_weights`' no-copy path registers `(buf → base, size)` in a small mutex-guarded side map
  alongside setting `WeightLoad::mmap_addr/mmap_len`.
- `release_weight_buffer(ggml_backend_buffer_t&)` takes-and-erases that entry in one critical
  section, frees the buffer, then unmaps, then nulls the caller's handle. Take *before* free, so a
  concurrent load that receives a new buffer at the same address cannot have its record erased. A
  missing entry is the ordinary case — the copy path maps nothing that outlives the load — and is
  released like any other buffer.
- `free_weights` routes every buffer through it and then clears `mmap_addr/mmap_len` **without**
  unmapping again. Those fields stay as the caller-visible record of a load; they are no longer a
  second owner.

Net behaviour for existing callers is unchanged, which is what the test below checks.

### The latent risk this leaves, and what closes it

Eleven sites across nine models in `src/` move `wl.buf` out of a **function-local** `WeightLoad` into
their own context and free it directly. The `WeightLoad` then dies at scope exit, taking `mmap_addr`
with it, so `free_weights` is never reached and nothing holds a handle to the mapping:

| site | freed handle |
|---|---|
| `src/bidirlm_vision.cpp:560` | `ctx.model_buf` |
| `src/fireredpunc.cpp:1085` | `ctx->buf` |
| `src/gliner_ner.cpp:1121` | `ctx->model.buf` |
| `src/glm_ocr.cpp:623` | `ctx.model_buf` |
| `src/got_ocr.cpp:422` | `ctx.model_buf` |
| `src/internvl2_ocr.cpp:1091` | `ctx.model_buf` |
| `src/lfm2_embed.cpp:328` | `ctx->model.buf` |
| `src/lfm2_embed.cpp:345` | `ctx->model.buf` |
| `src/pcs.cpp:982` | `ctx->buf` |
| `src/qwen2vl_ocr.cpp:1135` | `ctx.mmproj_buf` |
| `src/qwen2vl_ocr.cpp:1143` | `ctx.model_buf` |

(Derived by provenance, not by name: an expression assigned from a `WeightLoad` field and never also
from `ggml_backend_alloc_ctx_tensors` / `alloc_buffer` / `buft_alloc_buffer`. That second rule is
what keeps `kvc.buf`, `bake_buf` and the KV-cache buffers out of the list — those are separate
allocations and are freed correctly where they are.)

**Every one of them is correct only because its loader never maps.** There are two independent
one-word changes that break that, and they are worth separating because they do different things:

1. **Adding `try_mmap` to any of these eleven makes the leak happen.** That is a single argument at
   the `load_weights` call, of exactly the shape `deepseek_ocr2` and `unlimited_ocr` already use, and
   it is an attractive change — it is there to halve resident memory on a large model. Nothing at the
   call site says the teardown a few hundred lines away is now wrong.

2. **Changing the mapping mode makes a leak expensive rather than merely untidy.** Today's
   `PROT_READ | MAP_SHARED` leaves clean pages the kernel can drop under pressure. CrispASR's
   `MappedFile` takes a `writable` flag and maps `MAP_PRIVATE | PROT_READ|PROT_WRITE`, because some
   of its backends fold weights in place after load (parakeet's batch-norm-into-conv). A private
   writable mapping privatizes on first *read*, so the resident pages are dirty and anonymous and can
   only be compressed or swapped, never dropped. If CrispEmbed ever needs the same in-place folding,
   that flag flip turns every leaked mapping from reclaimable page cache into real memory held for
   the life of the process — which is the whole of the CrispASR#347 measurement (11.25 GB against
   7.73 GB for two models in one process).

Neither trigger is visible from the file it would be typed in.

**The fix is one line per site** — `ggml_backend_buffer_free(X)` → `core_gguf::release_weight_buffer(X)`
— and after this PR the function it needs already exists. `release_weight_buffer` is
`ggml_backend_buffer_free` plus a side-map release, so converting a site that never maps is
behaviourally identical; the conversion costs nothing and removes the coupling entirely.

**Those eleven are left out of this PR deliberately**, since none of them is wrong as written and I did
not want a compile-unblocking change to arrive as a sweep through eleven unrelated models. 
CrispASR#347 does the equivalent conversion on its side, so there is precedent for doing it in one pass.

### Tests

`tests/test_gguf_loader_mmap.cpp` already exercised the no-copy path and checked that the tensors
match the copy path. It now also asks the kernel which regions still name the weight file, rather
than inferring release from `free_weights` returning:

```
no-copy mmap path taken (used_mmap=1)
  alpha         185 elems  copy==mmap==written: OK
  beta.weight   768 elems  copy==mmap==written: OK
  gamma           1 elems  copy==mmap==written: OK
  weight file regions: 1 while loaded, 0 after free_weights
PASS: gguf_loader no-copy mmap == copy
```

This is what makes the routing change checkable at all: `free_weights` now reaches the mapping
through `release_weight_buffer` rather than through `mw.mmap_addr`, and a desync between where the
region is registered and where it is taken would leave the file mapped while clearing the field
anyway. The field cannot be the oracle.

Two notes on the check, both learned the hard way:

- **The positive control is load-bearing.** The first version of the probe compared against `/tmp`
  while the kernel reports the resolved `/private/tmp`, so it found zero regions *while the file was
  mapped* — and the absence assertion after the free would have passed for the wrong reason forever.
  It is caught because the control asserts at least one mapping exists before anything is released.
- **`proc_regionfilename` is not usable here.** Asked about the base of an anonymous region it
  answers with the file of the next region at or above that address, counting an unrelated neighbour
  as a mapping of the weight file. The probe reads `PROC_PIDREGIONPATHINFO`, which returns the region
  and its path in one record. Linux reads `/proc/self/maps`; elsewhere it reports unsupported and the
  check is skipped rather than silently passing.

Made to fail on purpose, by skipping the unmap inside `release_weight_buffer`:
`FAIL: free_weights left 1 mapping(s) of /tmp/crispembed_test_loader_mmap.gguf`.

### Verification

- `crispembed` and every test target build (macOS arm64, `-DGGML_METAL=ON`).
- `test-gguf-loader-mmap` passes, output above.
- `crisp_audio`, `crisp_punc` and `crisp_lid` all compile against the changed header with
  CrispASR#347 applied, and all three fail to compile without this change.
- clang-format 18.1.8 clean on all three changed files.

One pre-existing failure, unrelated and left alone: `firered-punct-ab` does not link when
`crisp_punc` comes from a sibling CrispASR checkout, because `_fireredpunc_debug_token_ids` is
defined in this repo's `src/fireredpunc.cpp` and not in CrispASR's `crisp_punc/` copy — the same
duplicated-file drift the header warns about, in the punctuation pair rather than the loader. It does
not appear in CI, which has no sibling checkout and so builds the local copies.

Authored by Claude Opus 5.